### PR TITLE
Fix internal player seek cancellation when toggling playback

### DIFF
--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -218,6 +218,7 @@ Routen (aus `MainActivity`):
 
 5. **player = `InternalPlayerScreen`**
    - Media3/ExoPlayer, Resume‑Handling (`ResumeRepository`), Untertitel‑Stil, Rotation‑Lock Option.
+   - Long-Press-Seeking stoppt sofort, wenn Play/Pause (oder Center) ausgelöst wird; das Seek-Coroutine wird beendet, bevor die Wiedergabe fortgesetzt wird.
 
 6. **settings = `SettingsScreen`**
    - Player-Modus (ask/internal/external + bevorzugtes externes Paket), Subtitle‑Stil, Header‑Verhalten, Autoplay Next, TV‑Filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2025-10-20
+- fix(player/seek): Long-press seeking now cancels immediately when Play/Pause is pressed, so the
+  internal player exits seek loops and resumes playback without continuing to fast-forward or rewind.
+
 2025-10-19
 - feat(player/ffmpeg): Internal player bundles Media3 FFmpeg codecs, prefers the extension renderers,
   and biases track selection towards premium audio/video formats at the highest supported bitrate. VOD,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,8 @@ Hinweis
   erfolgreich durchläuft.
 - Maintenance 2025‑10‑19: InternalPlayer nutzt die Media3-FFmpeg-Extension und priorisiert hochwertige Audio-/Video-Codecs
   (höchste verfügbare Bitrate und bevorzugte Formate werden automatisch gewählt).
+- Maintenance 2025‑10‑20: Long-Press-Spulen stoppt sofort, sobald Play/Pause ausgelöst wird. Der interne Player beendet
+  laufende Seek-Loops und reagiert unmittelbar auf den Wiedergabe-Befehl.
 
 Prio 1 — Tiles/Rows Centralization (ON)
 - Ziel: UI‑Layout vollständig zentralisieren (Tokens + Tile + Row + Content), damit Screens nur noch `FishRow` + `FishTile` verdrahten.

--- a/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
@@ -1196,6 +1196,9 @@ fun InternalPlayerScreen(
                             android.view.KeyEvent.KEYCODE_MEDIA_PLAY,
                             android.view.KeyEvent.KEYCODE_MEDIA_PAUSE -> {
                                 com.chris.m3usuite.core.debug.GlobalDebug.logDpad("CENTER/PLAY_PAUSE", mapOf("screen" to "player", "type" to type))
+                                if (seekRepeatJob != null || pendingLongPressJob != null || longPressActive) {
+                                    stopSeek()
+                                }
                                 if (type == "live") {
                                     // Toggle quick actions; if already focusing a button, let the button handle the click
                                     return@setOnKeyListener if (!quickActionsVisible) {


### PR DESCRIPTION
## Summary
- stop the internal player seek coroutine when Play/Pause (or center) is pressed so the player exits continuous seeking
- document the behavioral change in the changelog, roadmap, and architecture overview

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee9b346640832294c69514467133e3