### PR TITLE
Fix Media3 dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-10-20
+- fix(build/media3): Pin Media3 dependencies to 1.5.1 so Gradle can resolve the FFmpeg
+  extension again. Version 1.8.0 is not yet published on Maven Central/Google Maven and
+  broke `:app:checkDebugAarMetadata`.
+
 2025-10-19
 - feat(player/ffmpeg): Internal player bundles Media3 FFmpeg codecs, prefers the extension renderers,
   and biases track selection towards premium audio/video formats at the highest supported bitrate. VOD,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,8 @@ Hinweis
   erfolgreich durchläuft.
 - Maintenance 2025‑10‑19: InternalPlayer nutzt die Media3-FFmpeg-Extension und priorisiert hochwertige Audio-/Video-Codecs
   (höchste verfügbare Bitrate und bevorzugte Formate werden automatisch gewählt).
+- Maintenance 2025‑10‑20: Media3-Abhängigkeiten auf 1.5.1 fixiert, weil 1.8.0 noch nicht auf Google/Maven Central liegt und
+  den Gradle-Task `:app:checkDebugAarMetadata` blockiert hat.
 
 Prio 1 — Tiles/Rows Centralization (ON)
 - Ziel: UI‑Layout vollständig zentralisieren (Tokens + Tile + Row + Content), damit Screens nur noch `FishRow` + `FishTile` verdrahten.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -261,7 +261,7 @@ dependencies {
     implementation("com.google.android.material:material:1.13.0")
 
     // Media3 (ExoPlayer + UI + HLS)
-    val media3 = "1.8.0"
+    val media3 = "1.5.1"
     implementation("androidx.media3:media3-exoplayer:$media3")
     implementation("androidx.media3:media3-ui:$media3")
     implementation("androidx.media3:media3-exoplayer-hls:$media3")


### PR DESCRIPTION
## Summary
- pin the Media3 dependency version to 1.5.1 so the FFmpeg artifact resolves again
- document the build fix in the changelog and roadmap

## Testing
- `./gradlew :app:checkDebugAarMetadata` *(fails: SDK location not configured in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68eea6fd89a883228f63f858f9f71bd9