### PR TITLE
Improve TDLib robustness and streaming heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2025-10-22
+- feat(telegram/tdlib): Harden the reflection bridge with retry/backoff-aware
+  `sendForResult` calls, trace tags, and explicit timeouts for every TDLib
+  request. Failures now surface predictable logs and avoid stuck handlers.
+- fix(telegram/playback): TelegramTdlibDataSource reads ObjectBox metadata
+  before issuing TDLib calls, applies streamability heuristics, waits for full
+  downloads when TDLib flags files as non-streamable, and persistently caches
+  the resolved local path. Playback now recovers gracefully when TDLib stalls
+  and falls back to routing with user messaging when required.
+- fix(telegram/routing): Align the routing datasource and thumbnail helpers
+  with the new robust TDLib invocation pattern so chat lookups and thumbnail
+  downloads reuse the same retry/backoff semantics.
+
 2025-10-21
 - feat(player/media3): Upgrade the Media3 stack to 1.8.0 now that the release
   is available on Google Maven again. Keeps ExoPlayer current and aligned with


### PR DESCRIPTION
## Summary
- harden TdLibReflection.sendForResult with retry/backoff, timeouts, and trace tagging so all callers get consistent error handling
- make TelegramTdlibDataSource stream-aware by reusing cached metadata, waiting for non-streamable media to download, persisting paths, and surfacing fallbacks
- align Telegram routing datasource, service calls, and media mappers with the new TDLib invocation pattern
- document the updated TDLib behaviour in ARCHITECTURE_OVERVIEW and CHANGELOG

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing Android SDK in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eebc041b348322a596e0ad204ed2d5