### PR TITLE
Fix Media3 FFmpeg dependency resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,9 @@ Recent
 - TV/DPAD focus (gate): ProfileGate tiles now use `tvClickable` + `tvFocusableItem` within a `focusGroup()` container, with a guarded initial `FocusRequester`. On TV, the first profile tile is highlighted immediately; DPAD navigation shows halo/scale.
 - TV/DPAD focus (PIN): The PIN numpad uses `TvButton`/`TvTextButton` for keys (0–9, backspace, OK). The grid container is a `focusGroup()` and the first key requests initial focus. Visual focus (halo + scale) is consistent with other TV buttons.
 - Manifest/Gradle: Added leanback/DPAD features (non‑required) and ensured TV libraries are available. Behavior is a no‑op on phones and tablets.
+- Media3 FFmpeg: Google Maven ships no FFmpeg artifacts. We vendor Jellyfin's `org.jellyfin.media3:media3-ffmpeg-decoder:1.8.0+1`
+  AAR (GPL-3.0). Keep Media3 core artifacts on version `1.8.0` and ensure our ABI filters stay aligned with the bundled `.so`
+  set (arm64-v8a + armeabi-v7a by default).
 
 - Playback-aware seeding: While the internal player is active, `m3u_workers_enabled` is temporarily forced OFF and current Xtream jobs are canceled; on exit, the flag is restored if it was previously ON. This ensures background seeding does not contend with playback on low-power devices.
 - Home initial focus: Start screen sets the first focus deterministically to the first tile of the topmost card (Series). Only the Series row is eligible to request initial focus; VOD/Live rows suppress initial focus on Start. Implemented via `RowConfig.initialFocusEligible` + StartScreen wiring.

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -314,8 +314,11 @@ Backup/Restore
 - Images/Coil (v3): Globaler ImageLoader mit Hardware‑Bitmaps, ~25% RAM‑Cache und dynamischem Disk‑Cache (32‑bit ≈256 MiB, 64‑bit ≈512 MiB; Caps 384/768 MiB; mind. 2% frei). Requests lesen ihre Slot‑Größe via `onSizeChanged`, nutzen RGB_565 global, vergeben WxH‑sensitive Cache‑Keys und überschreiben TMDb‑URLs passend (`AppPosterImage`/`AppHeroImage`). ContentScale: Logos=Fit, Avatare=Crop, Karten=Crop; Standard‑Fallbacks stammen aus den neuen Fish‑Assets.
 - Player (Media3): `PlayerComponents.renderersFactory` liefert eine gemeinsam genutzte
   `DefaultRenderersFactory`, die Decoder‑Fallback aktiviert und die FFmpeg-
-  Extension bevorzugt. `PlayerView` verwendet weiterhin `surface_view` (TV
-  performanter). `DefaultLoadControl` bleibt konservativ.
+  Extension bevorzugt. Die FFmpeg-Decoder stammen aus Jellyfins vorgebautem
+  `media3-ffmpeg-decoder` 1.8.0+1 AAR (GPL-3.0), daher bleiben alle Media3-Module
+  bei 1.8.0 und die ABI-Splits sind auf arm64-v8a/armeabi-v7a festgelegt.
+  `PlayerView` verwendet weiterhin `surface_view` (TV performanter).
+  `DefaultLoadControl` bleibt konservativ.
 - TV Mini‑Player: Der Mini‑Player wird global im `HomeChromeScaffold` als Overlay (unten rechts) gehostet. Auf TV aktiviert der PiP‑Button den Mini statt System‑PiP; die Menü‑Taste (MENU) fokussiert den Mini, sofern sichtbar. Bei expandiertem Chrome bleibt der Mini sichtbar, ist aber nicht fokusierbar. Der ExoPlayer wird über `PlaybackSession` geteilt, sodass der Mini beim Navigieren weiter spielt. `MiniPlayerHost` rendert das PlayerView-Preview plus Titel/Unterzeile/Progress und nutzt `MiniPlayerState` + `MiniPlayerDescriptor`; `LocalMiniPlayerResume` in `MainActivity` navigiert zurück zur Player-Route ohne das ExoPlayer-Objekt zu ersetzen.
 - UI‑State: Scrollpositionen von LazyColumn/LazyRow/LazyVerticalGrid werden pro Route/Gruppe gespeichert und beim Wiederbetreten wiederhergestellt. Zentrale Helper in `ui/state/ScrollStateRegistry.kt` (`rememberRouteListState`, `rememberRouteGridState`).
 - XtreamSeeder / XtreamObxRepository: Kopf-Import (Live/VOD/Series) erstellt Provider-/Genre-/Year-Indizes (`ObxIndex*`) direkt aus den Xtream-Listen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-10-23
+- fix(build/media3): Replace the missing Google Maven FFmpeg artifact with Jellyfin's
+  `media3-ffmpeg-decoder` 1.8.0+1 build so Gradle resolves Media3 1.8.0 again while
+  keeping the internal player wired to FFmpeg codecs.
+
 2025-10-22
 - feat(telegram/tdlib): Harden the reflection bridge with retry/backoff-aware
   `sendForResult` calls, trace tags, and explicit timeouts for every TDLib

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,6 +22,10 @@ Hinweis
   Trailer-Preview teilen sich eine RenderersFactory, die die FFmpeg-Extension
   bevorzugt und Decoder-Fallback aktiviert lässt.
 
+- Maintenance 2025‑10‑23: Build block durch fehlendes Media3-FFmpeg-AAR gelöst.
+  Wir binden Jellyfins `media3-ffmpeg-decoder` 1.8.0+1 ein, halten die restlichen
+  Media3-Module auf 1.8.0 und behalten die bisherigen ABI-Splits bei.
+
 Prio 1 — Tiles/Rows Centralization (ON)
 - Ziel: UI‑Layout vollständig zentralisieren (Tokens + Tile + Row + Content), damit Screens nur noch `FishRow` + `FishTile` verdrahten.
 - Module (Stand): `ui/layout/FishTheme`, `FishTile`, `FishRow(Light/Media/Paged)`, `FishVodContent` (VOD), `FishSeriesContent`/`FishLiveContent` (Basis), `FishMeta`, `FishActions`, `FishLogging`, `FishResumeTile`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -265,7 +265,8 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer:$media3")
     implementation("androidx.media3:media3-ui:$media3")
     implementation("androidx.media3:media3-exoplayer-hls:$media3")
-    implementation("androidx.media3:media3-exoplayer-ffmpeg:$media3")
+    // FFmpeg decoder bundle (prebuilt Jellyfin distribution, GPL-3.0)
+    implementation("org.jellyfin.media3:media3-ffmpeg-decoder:1.8.0+1")
     // Optional:
     // implementation("androidx.media3:media3-ui-compose:$media3")
 


### PR DESCRIPTION
## Summary
- replace the unavailable androidx Media3 FFmpeg artifact with Jellyfin's 1.8.0+1 decoder build
- document the new dependency and ABI expectations in AGENTS.md, ROADMAP.md, and ARCHITECTURE_OVERVIEW.md
- note the build fix in the changelog

## Testing
- ./gradlew :app:checkDebugAarMetadata *(fails: Android SDK not provisioned in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ef34e57b1083228095b29d45b3f24d