### PR TITLE
Fix Kotlin 2.0 TDLib reflection array inference

### DIFF
--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -26,12 +26,15 @@ Dieses Dokument bietet den vollständigen, detaillierten Überblick über Module
 
 - Feature Flag: Global in Settings (`tg_enabled`, default false). Zusatzoptionen: `tg_selected_chats_csv`, `tg_cache_limit_gb`.
  - ObjectBox: Telegram messages are stored in `ObxTelegramMessage` (chatId/messageId/fileId/uniqueId/supportsStreaming/caption/date/localPath/thumbFileId). Repository/DataSources update OBX directly.
-- Login (Alpha): Reflection‑Bridge `telegram/TdLibReflection.kt` + `TelegramAuthRepository` (kein direkter TDLib‑Compile‑Dep). Settings: Button „Telegram verbinden“ (Telefon → Code → Passwort), auto DB‑Key‑Check, Status‑Debug. Telefon-Eingabe nutzt `PhoneNumberAuthenticationSettings` (Tokens + `is_current_phone_number` Toggle im UI) für Single-Device-Logins; bei `authorizationStateWaitOtherDevice` öffnet die App den `tg://login` Link automatisch, wenn die Telegram-App lokal installiert ist. Falls QR nicht möglich ist, bietet der Dialog einen Button „Per Code anmelden“, der den klassischen SMS-Code-Flow erneut startet.
+- Login (Alpha): Reflection‑Bridge `telegram/TdLibReflection.kt` + `TelegramAuthRepository` (kein direkter TDLib‑Compile‑Dep). Settings: Button „Telegram verbinden“ (Telefon → Code → Passwort), auto DB‑Key‑Check, Status‑Debug. Telefon-Eingabe nutzt `PhoneNumberAuthenticationSettings` (Tokens + `is_current_phone_number` Toggle im UI) für Single-Device-Logins; bei `authorizationStateWaitOtherDevice` öffnet die App den `tg://login` Link automatisch, wenn die Telegram-App lokal installiert ist. Falls QR nicht möglich ist, bietet der Dialog einen Button „Per Code anmelden“, der den klassischen SMS-Code-Flow erneut startet. Kotlin 2.0 verlangt, dass die Reflection-Konstruktoren ihre Parameterlisten als `Array<Class<*>>` übergeben; der Bridge hält dies für Auto-Download und PhoneAuth konsistent ein.
 - TdLibReflection `sendForResult` kapselt nun Timeouts, Retry/Backoff und optionale
   Trace-Tags pro Aufruf. Service, Datasource und Mapper übergeben sprechende
   Tags („History[…]“, „Chats:…“, „MediaMapper:…“), damit Logcat die
   jeweiligen Requests klar zuordnet und fehlerhafte Antworten automatisch
   retried oder sauber abgebrochen werden.
+- Kotlin 2.0 benötigt explizite `Array<Class<*>>`-Parameterlisten für reflektierte
+  TDLib-Konstruktoren; TdLibReflection setzt diese nun typisiert zusammen, damit
+  Release-Builds nicht an `Comparable & Serializable`-Schnittmengen scheitern.
 - Playback DataSource: `TelegramRoutingDataSource` für Media3 routet `tg://message?chatId=&messageId=` auf lokale Pfade und triggert bei Bedarf `DownloadFile(fileId)`; `localPath` wird persistiert.
 - Settings: Film/Serien Sync zeigt Chat‑Picker (Hauptordner/Archiv) und zeigt die gewählten Chats mit Namen an (wenn AUTHENTICATED).
 - Sync: `TelegramSyncWorker` (manueller Backfill) ruft pro ausgewähltem Chat `CMD_PULL_CHAT_HISTORY` im Service auf. Der Service nutzt `getChatHistory` (limit=200) und `indexMessageContent(..)` für `ObxTelegramMessage`. Mapping auf VOD/Serien‑Modelle folgt heuristisch in Phase‑2. Der Worker sammelt Neuheiten (Filme/Serien/Episoden) und publiziert sie über `SchedulingGateway.telegramSyncState`; HomeChrome blendet währenddessen einen nicht-blockierenden „Telegram Sync“-Banner mit Fortschritt/Resultat ein.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2025-10-26
+- fix(telegram/tdlib): Align reflection constructor parameter arrays with Kotlin
+  2.0's stricter `arrayOf` inference so release builds stop reporting
+  `Array<Class<out Comparable<*> & Serializable>>` mismatches.
+- fix(telegram/settings): Import the FishForm slider composable so the Telegram
+  Settings sliders compile again under Kotlin 2.0.
+- fix(telegram/tdlib): Explicitly type the phone-auth settings constructor
+  parameters as `Array<Class<*>>` so Kotlin 2.0 release builds accept the
+  mixed primitive/custom class signatures TDLib expects.
+
 2025-10-25
 - feat(telegram/settings): Expose full TDLib runtime controls in Settings. Users can
   toggle IPv6 preference, persistent online status, storage optimizer, and log

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,10 @@ Hinweis
   Status, Proxy/Loglevel, Auto-Download-Profile, Streaming-Prefetch, Seek-Boost,
   parallele Downloads und Storage-Optimizer sind direkt in den Settings
   schaltbar und werden beim Start konsistent auf TDLib angewendet.
+- Maintenance 2025‑10‑26: Kotlin 2.0 Inferenz-Probleme im TDLib-Reflection-Pfad
+  (Auto-Download + PhoneAuth-Constructor Arrays sind jetzt `Array<Class<*>>`)
+  und in den Telegram-Settings korrigiert, damit Release-Builds wieder
+  kompilieren.
 - Maintenance 2025‑10‑23: Build block durch fehlendes Media3-FFmpeg-AAR gelöst.
   Wir binden Jellyfins `media3-ffmpeg-decoder` 1.8.0+1 ein, halten die restlichen
   Media3-Module auf 1.8.0 und behalten die bisherigen ABI-Splits bei.

--- a/app/src/main/java/com/chris/m3usuite/telegram/TdLibReflection.kt
+++ b/app/src/main/java/com/chris/m3usuite/telegram/TdLibReflection.kt
@@ -308,7 +308,7 @@ object TdLibReflection {
         val fn = runCatching {
             new(
                 "TdApi\$SetOption",
-                arrayOf(String::class.java, td("TdApi\$OptionValue")),
+                arrayOf<Class<*>>(String::class.java, td("TdApi\$OptionValue")),
                 arrayOf(name, optionValue)
             )
         }.getOrNull() ?: return
@@ -395,7 +395,7 @@ object TdLibReflection {
     }
 
     private fun buildAutoDownloadSettings(settings: AutoDownloadSettings): Any? {
-        val paramTypes = arrayOf(
+        val paramTypes: Array<Class<*>> = arrayOf(
             Boolean::class.javaPrimitiveType!!,
             Long::class.javaPrimitiveType!!,
             Long::class.javaPrimitiveType!!,
@@ -451,7 +451,7 @@ object TdLibReflection {
         val fn = runCatching {
             new(
                 "TdApi\$SetAutoDownloadSettings",
-                arrayOf(td("TdApi\$AutoDownloadSettings"), td("TdApi\$NetworkType")),
+                arrayOf<Class<*>>(td("TdApi\$AutoDownloadSettings"), td("TdApi\$NetworkType")),
                 arrayOf(settingsObj, networkObj)
             )
         }.getOrNull() ?: return
@@ -519,21 +519,21 @@ object TdLibReflection {
             ProxyKind.SOCKS5 -> runCatching {
                 new(
                     "TdApi\$ProxyTypeSocks5",
-                    arrayOf(String::class.java, String::class.java),
+                    arrayOf<Class<*>>(String::class.java, String::class.java),
                     arrayOf(config.username, config.password)
                 )
             }.getOrNull()
             ProxyKind.HTTP -> runCatching {
                 new(
                     "TdApi\$ProxyTypeHttp",
-                    arrayOf(String::class.java, String::class.java, Boolean::class.javaPrimitiveType!!),
+                    arrayOf<Class<*>>(String::class.java, String::class.java, Boolean::class.javaPrimitiveType!!),
                     arrayOf(config.username, config.password, false)
                 )
             }.getOrNull()
             ProxyKind.MTPROTO -> runCatching {
                 new(
                     "TdApi\$ProxyTypeMtproto",
-                    arrayOf(String::class.java),
+                    arrayOf<Class<*>>(String::class.java),
                     arrayOf(config.secret)
                 )
             }.getOrNull()
@@ -545,7 +545,7 @@ object TdLibReflection {
         val fn = runCatching {
             new(
                 "TdApi\$AddProxy",
-                arrayOf(String::class.java, Int::class.javaPrimitiveType!!, Boolean::class.javaPrimitiveType!!, td("TdApi\$ProxyType")),
+                arrayOf<Class<*>>(String::class.java, Int::class.javaPrimitiveType!!, Boolean::class.javaPrimitiveType!!, td("TdApi\$ProxyType")),
                 arrayOf(config.host, config.port, config.enabled, proxyType)
             )
         }.getOrNull() ?: return false
@@ -700,7 +700,7 @@ object TdLibReflection {
     }
 
     fun sendSetTdlibParameters(client: ClientHandle, parameters: Any) {
-        val set = new("TdApi\$SetTdlibParameters", arrayOf(td("TdApi\$TdlibParameters")), arrayOf(parameters))
+        val set = new("TdApi\$SetTdlibParameters", arrayOf<Class<*>>(td("TdApi\$TdlibParameters")), arrayOf(parameters))
         val handlerType = td("Client\$ResultHandler")
         val exceptionHandlerType = td("Client\$ExceptionHandler")
         val rh = java.lang.reflect.Proxy.newProxyInstance(handlerType.classLoader, arrayOf(handlerType)) { _, _, _ -> null }
@@ -711,7 +711,7 @@ object TdLibReflection {
     fun buildPhoneNumberAuthenticationSettings(settings: PhoneAuthSettings): Any? {
         val tokens = settings.authenticationTokens.distinct().take(20).toTypedArray()
         val firebaseClass = runCatching { td("TdApi\$FirebaseAuthenticationSettings") }.getOrNull() ?: return null
-        val paramTypes = arrayOf(
+        val paramTypes: Array<Class<*>> = arrayOf(
             Boolean::class.javaPrimitiveType!!,
             Boolean::class.javaPrimitiveType!!,
             Boolean::class.javaPrimitiveType!!,
@@ -734,15 +734,15 @@ object TdLibReflection {
 
     fun sendSetPhoneNumber(client: ClientHandle, phone: String, settings: PhoneAuthSettings = PhoneAuthSettings()) {
         val settingsObj = buildPhoneNumberAuthenticationSettings(settings)
-            ?: new(
-                "TdApi\$PhoneNumberAuthenticationSettings",
-                arrayOf(
-                    Boolean::class.javaPrimitiveType!!,
-                    Boolean::class.javaPrimitiveType!!,
-                    Boolean::class.javaPrimitiveType!!,
-                    Boolean::class.javaPrimitiveType!!,
-                    Array<String>::class.java
-                ),
+                ?: new(
+                    "TdApi\$PhoneNumberAuthenticationSettings",
+                    arrayOf<Class<*>>(
+                        Boolean::class.javaPrimitiveType!!,
+                        Boolean::class.javaPrimitiveType!!,
+                        Boolean::class.javaPrimitiveType!!,
+                        Boolean::class.javaPrimitiveType!!,
+                        Array<String>::class.java
+                    ),
                 arrayOf(
                     settings.allowFlashCall,
                     settings.allowMissedCall,
@@ -753,7 +753,7 @@ object TdLibReflection {
             )
         val fn = new(
             "TdApi\$SetAuthenticationPhoneNumber",
-            arrayOf(String::class.java, settingsObj.javaClass),
+            arrayOf<Class<*>>(String::class.java, settingsObj.javaClass),
             arrayOf(phone, settingsObj)
         )
         val handlerType = td("Client\$ResultHandler")
@@ -771,7 +771,7 @@ object TdLibReflection {
     }
 
     fun sendCheckCode(client: ClientHandle, code: String) {
-        val fn = new("TdApi\$CheckAuthenticationCode", arrayOf(String::class.java), arrayOf(code))
+        val fn = new("TdApi\$CheckAuthenticationCode", arrayOf<Class<*>>(String::class.java), arrayOf(code))
         val handlerType = td("Client\$ResultHandler")
         val exceptionHandlerType = td("Client\$ExceptionHandler")
         val rh = java.lang.reflect.Proxy.newProxyInstance(handlerType.classLoader, arrayOf(handlerType)) { _, _, args ->
@@ -829,7 +829,7 @@ object TdLibReflection {
     }
 
     fun sendCheckPassword(client: ClientHandle, password: String) {
-        val fn = new("TdApi\$CheckAuthenticationPassword", arrayOf(String::class.java), arrayOf(password))
+        val fn = new("TdApi\$CheckAuthenticationPassword", arrayOf<Class<*>>(String::class.java), arrayOf(password))
         val handlerType = td("Client\$ResultHandler")
         val exceptionHandlerType = td("Client\$ExceptionHandler")
         val rh = java.lang.reflect.Proxy.newProxyInstance(handlerType.classLoader, arrayOf(handlerType)) { _, _, args ->
@@ -868,9 +868,9 @@ object TdLibReflection {
         // Build DeviceTokenFirebaseCloudMessaging with best-effort constructor resolution
         val tokenObj = runCatching {
             // Newer: (String token, boolean encrypt, String data)
-            new("TdApi\$DeviceTokenFirebaseCloudMessaging", arrayOf(String::class.java, Boolean::class.javaPrimitiveType!!, String::class.java), arrayOf(fcmToken, false, ""))
+            new("TdApi\$DeviceTokenFirebaseCloudMessaging", arrayOf<Class<*>>(String::class.java, Boolean::class.javaPrimitiveType!!, String::class.java), arrayOf(fcmToken, false, ""))
         }.getOrElse {
-            runCatching { new("TdApi\$DeviceTokenFirebaseCloudMessaging", arrayOf(String::class.java, Boolean::class.javaPrimitiveType!!), arrayOf(fcmToken, false)) }.getOrNull()
+            runCatching { new("TdApi\$DeviceTokenFirebaseCloudMessaging", arrayOf<Class<*>>(String::class.java, Boolean::class.javaPrimitiveType!!), arrayOf(fcmToken, false)) }.getOrNull()
         } ?: return
         val superCls = (tokenObj.javaClass.superclass as Class<*>)
         val arrCls = java.lang.reflect.Array.newInstance(superCls, 1).javaClass // DeviceToken[]
@@ -884,7 +884,7 @@ object TdLibReflection {
         val exceptionHandlerType = td("Client\$ExceptionHandler")
         val rh = java.lang.reflect.Proxy.newProxyInstance(handlerType.classLoader, arrayOf(handlerType)) { _, _, _ -> null }
         val eh = java.lang.reflect.Proxy.newProxyInstance(exceptionHandlerType.classLoader, arrayOf(exceptionHandlerType)) { _, _, _ -> null }
-        val fn = runCatching { new("TdApi\$ProcessPushNotification", arrayOf(String::class.java), arrayOf(payload)) }.getOrNull() ?: return
+        val fn = runCatching { new("TdApi\$ProcessPushNotification", arrayOf<Class<*>>(String::class.java), arrayOf(payload)) }.getOrNull() ?: return
         client.sendMethod.invoke(client.client, fn, rh, eh)
     }
 

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
@@ -72,6 +72,7 @@ import com.chris.m3usuite.core.http.HttpClientFactory
 import com.chris.m3usuite.ui.focus.tvClickable
 import com.chris.m3usuite.ui.layout.FishFormSection
 import com.chris.m3usuite.ui.layout.FishFormSelect
+import com.chris.m3usuite.ui.layout.FishFormSlider
 import com.chris.m3usuite.ui.layout.FishFormSwitch
 import com.chris.m3usuite.ui.layout.FishFormTextField
 import com.chris.m3usuite.ui.layout.TvKeyboard
@@ -1183,7 +1184,7 @@ fun SettingsScreen(
                     onValueChange = { newValue -> scope.launch { store.setTelegramSelectedChatsCsv(newValue) } },
                     helperText = "Kommagetrennte Chat-IDs; leer = Auswahl über Picker",
                 )
-                com.chris.m3usuite.ui.layout.FishFormSlider(
+                FishFormSlider(
                     label = "Cache-Limit (GB)",
                     value = tgCacheGb,
                     range = 1..20,


### PR DESCRIPTION
## Summary
- ensure TdLibReflection uses explicit `Array<Class<*>>` signatures for auto-download and phone-auth constructors so Kotlin 2.0 release builds compile cleanly
- document the Kotlin 2.0 reflection fix across the architecture overview, changelog, and roadmap

## Testing
- ./gradlew :app:compileReleaseKotlin *(fails: Android SDK not provisioned in container)*

------
https://chatgpt.com/codex/tasks/task_e_68effbb904c88322b2f89c35f2bf1f8f