### PR TITLE
Fix Telegram login submission and enable touch slider control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2025-10-29
+- fix(telegram/auth): Normalize phone numbers before sending from the UI, show a
+  clear error when TDLib cannot be started, and immediately refresh the auth
+  state so phone/code logins progress after submitting the number.
+- fix(settings/telegram): Allow the TDLib log level slider to be adjusted on
+  touch devices by adding a Material slider fallback while keeping DPAD
+  controls on TV.
+
 2025-10-28
 - feat(telegram/debug): Added an on-screen TDLib log overlay that streams recent
   Telegram logs as snackbars whenever the new settings toggle is enabled and the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
 - Maintenance 2025‑10‑28: Telegram-Logs lassen sich nun per Settings-Schalter live als Snackbar einblenden; ideal für mehrstufige TDLib-Diagnosen ohne Logcat.
+- Maintenance 2025‑10‑29: Telegram-Login akzeptiert wieder lokale Nummern ohne "+" und meldet fehlende TDLib-Starts sofort. Der TDLib-Loglevel lässt sich auf Touch-Geräten über einen Slider anpassen.
 - Maintenance 2025‑10‑27: Telegram‑Login normalisiert lokale Telefonnummern via Gerätestandort (E.164), sodass WAIT_FOR_NUMBER nach Eingabe ohne führendes "+" nicht mehr hängen bleibt.
 - Maintenance 2025‑09‑27: Manifest‑Icon auf `@mipmap/ic_launcher` (+ `roundIcon`) vereinheitlicht; kein Roadmap‑Impact.
 - Maintenance 2025‑09‑28: Build‑Blocking Lücken geschlossen (Nav‑Extension, TV‑Focus‑Compat, TvRowScroll, safePainter, Adults‑Filter, XtreamImportCoordinator). Kein neues Feature; Roadmap unverändert.

--- a/app/src/main/java/com/chris/m3usuite/telegram/PhoneNumberSanitizer.kt
+++ b/app/src/main/java/com/chris/m3usuite/telegram/PhoneNumberSanitizer.kt
@@ -1,0 +1,45 @@
+package com.chris.m3usuite.telegram
+
+import android.content.Context
+import android.telephony.PhoneNumberUtils
+import android.telephony.TelephonyManager
+import java.util.Locale
+
+/**
+ * Normalizes phone numbers for Telegram login flows.
+ * Removes formatting characters, translates leading "00" to "+"
+ * and, if needed, converts the number to E.164 using the best matching
+ * country ISO derived from network, SIM or device locale.
+ */
+object PhoneNumberSanitizer {
+    private val trimRegex = Regex("[\\s\\-()]+")
+
+    fun sanitize(context: Context, raw: String): String {
+        var value = raw.replace(trimRegex, "").trim()
+        if (value.startsWith("00")) {
+            value = "+" + value.drop(2)
+        }
+        if (!value.startsWith("+")) {
+            val iso = detectDefaultCountryIso(context)
+            if (!iso.isNullOrBlank()) {
+                val normalized = runCatching { PhoneNumberUtils.formatNumberToE164(value, iso) }.getOrNull()
+                if (!normalized.isNullOrBlank()) {
+                    value = normalized
+                }
+            }
+        }
+        return value
+    }
+
+    private fun detectDefaultCountryIso(context: Context): String? {
+        val tm = context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+        val candidates = listOfNotNull(
+            tm?.networkCountryIso,
+            tm?.simCountryIso,
+            Locale.getDefault().country
+        )
+        val iso = candidates.firstOrNull { !it.isNullOrBlank() }
+        return iso?.uppercase(Locale.US)
+    }
+}
+


### PR DESCRIPTION
## Summary
- normalize Telegram phone submissions in the auth repository and reuse the sanitizer from a shared helper to keep TDLib progressing after phone entry
- surface start failures directly in the login dialog, request fresh auth state after submissions, and allow fallback phone login during QR flows
- add a touch-friendly Material slider to FishFormSlider while keeping TV DPAD support and document the fixes in the changelog and roadmap

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not configured in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68f08cf5b9488322bc2ab604b0524ee5