### PR TITLE
Fix Telegram TDLib service Locale import for release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-10-31
+- fix(build): Import `java.util.Locale` in `TelegramTdlibService` so release builds
+  compile again on Kotlin 2.0 after the locale-based proxy/auto-download parsing
+  changes.
+
 2025-10-30
 - feat(telegram/player): Replace the legacy TelegramTdlibDataSource with a
   TDLib-backed random access source that streams `tg://file/<fileId>` URIs on

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,8 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025‑10‑31: Release-Builds schlagen nicht mehr auf fehlendem `Locale`-Import
+  im Telegram-Dienst fehl; Kotlin 2.0 Release kann wieder kompiliert werden.
 - Maintenance 2025‑10‑28: Telegram-Logs lassen sich nun per Settings-Schalter live als Snackbar einblenden; ideal für mehrstufige TDLib-Diagnosen ohne Logcat.
 - Maintenance 2025‑10‑29: Telegram-Login akzeptiert wieder lokale Nummern ohne "+" und meldet fehlende TDLib-Starts sofort. Der TDLib-Loglevel lässt sich auf Touch-Geräten über einen Slider anpassen.
 - Maintenance 2025‑10‑27: Telegram‑Login normalisiert lokale Telefonnummern via Gerätestandort (E.164), sodass WAIT_FOR_NUMBER nach Eingabe ohne führendes "+" nicht mehr hängen bleibt.

--- a/app/src/main/java/com/chris/m3usuite/telegram/service/TelegramTdlibService.kt
+++ b/app/src/main/java/com/chris/m3usuite/telegram/service/TelegramTdlibService.kt
@@ -13,8 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import java.util.Locale
 
 /**
  * Dedicated TDLib service running in its own process. Minimal IPC via Messenger.


### PR DESCRIPTION
## Summary
- add the missing `java.util.Locale` import so the Telegram TDLib service can compile on release builds
- document the maintenance fix in the changelog and roadmap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2008daec483229e3449d8e0f8019c