### PR TITLE
Fix release minify by bundling SLF4J Android binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2025-11-07
+- fix(build): Bundle the `slf4j-android` binding so Junrar no longer triggers
+  missing `StaticLoggerBinder` classes during release R8 minification.
+
 2025-11-06
 - fix(start/telegram): Align the aggregated "Telegram Serien" row with the
   FishRow/SeriesFishTile contract so Kotlin 2.0 compiles again (new/assign/play

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,8 @@ Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
 - Maintenance 2025‑10‑31: Release-Builds schlagen nicht mehr auf fehlendem `Locale`-Import
   im Telegram-Dienst fehl; Kotlin 2.0 Release kann wieder kompiliert werden.
+- Maintenance 2025-11-07: Release-Minify bindet jetzt `slf4j-android`, damit Junrar
+  im R8-Schritt keinen `StaticLoggerBinder`-Fehler mehr auslöst.
 - Maintenance 2025‑10‑28: Telegram-Logs lassen sich nun per Settings-Schalter live als Snackbar einblenden; ideal für mehrstufige TDLib-Diagnosen ohne Logcat.
 - Maintenance 2025‑10‑29: Telegram-Login akzeptiert wieder lokale Nummern ohne "+" und meldet fehlende TDLib-Starts sofort. Der TDLib-Loglevel lässt sich auf Touch-Geräten über einen Slider anpassen.
 - Maintenance 2025‑10‑27: Telegram‑Login normalisiert lokale Telefonnummern via Gerätestandort (E.164), sodass WAIT_FOR_NUMBER nach Eingabe ohne führendes "+" nicht mehr hängen bleibt.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -287,6 +287,9 @@ dependencies {
     implementation("com.squareup.okio:okio:3.16.1")
     implementation("com.github.junrar:junrar:7.5.5")
 
+    // Logging (SLF4J binding required by Junrar when running R8)
+    implementation("org.slf4j:slf4j-android:1.7.36")
+
     // JSON (Kotlin Serialization)
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 


### PR DESCRIPTION
## Summary
- add the `slf4j-android` binding so Junrar has a StaticLoggerBinder during R8 release minification
- document the build fix in CHANGELOG.md and ROADMAP.md

## Testing
- `./gradlew :app:minifyReleaseWithR8` *(fails: local environment has no Android SDK configured)*

------
https://chatgpt.com/codex/tasks/task_e_68f4b1c20ef08322874becc2a667597c