### PR TITLE
Restore HomeChrome library shortcuts on Start header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 2025-11-07
 - fix(build): Bundle the `slf4j-android` binding so Junrar no longer triggers
   missing `StaticLoggerBinder` classes during release R8 minification.
+- fix(ui/homechrome): Restored the Live/VOD/Serien quick actions in the
+  HomeChrome header on Start by wiring `LibraryNavConfig` so the overlay renders
+  the library shortcuts on phone and TV again.
 
 2025-11-06
 - fix(start/telegram): Align the aggregated "Telegram Serien" row with the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,6 +7,9 @@ Hinweis
   im Telegram-Dienst fehl; Kotlin 2.0 Release kann wieder kompiliert werden.
 - Maintenance 2025-11-07: Release-Minify bindet jetzt `slf4j-android`, damit Junrar
   im R8-Schritt keinen `StaticLoggerBinder`-Fehler mehr auslöst.
+- Maintenance 2025-11-07: Start-Header blendet die Live/VOD/Serien-Schalter wieder
+  direkt im HomeChrome ein (LibraryNavConfig auf Start), sodass Telefon- und TV-UIs
+  die Bibliotheksnavigation oben neben Suche/Profil/Einstellungen anzeigen.
 - Maintenance 2025‑10‑28: Telegram-Logs lassen sich nun per Settings-Schalter live als Snackbar einblenden; ideal für mehrstufige TDLib-Diagnosen ohne Logcat.
 - Maintenance 2025‑10‑29: Telegram-Login akzeptiert wieder lokale Nummern ohne "+" und meldet fehlende TDLib-Starts sofort. Der TDLib-Loglevel lässt sich auf Touch-Geräten über einen Slider anpassen.
 - Maintenance 2025‑10‑27: Telegram‑Login normalisiert lokale Telefonnummern via Gerätestandort (E.164), sodass WAIT_FOR_NUMBER nach Eingabe ohne führendes "+" nicht mehr hängen bleibt.

--- a/app/src/main/java/com/chris/m3usuite/ui/home/StartScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/home/StartScreen.kt
@@ -136,6 +136,14 @@ fun StartScreen(
     val permRepo = remember { com.chris.m3usuite.data.repo.PermissionRepository(ctx, store) }
     val resumeRepo = remember { com.chris.m3usuite.data.repo.ResumeRepository(ctx) }
     val showAdults by store.showAdults.collectAsStateWithLifecycle(initialValue = false)
+    val libraryTabIndex by store.libraryTabIndex.collectAsStateWithLifecycle(initialValue = 0)
+    val headerLibraryTab = remember(libraryTabIndex) {
+        when (libraryTabIndex) {
+            0 -> LibraryTab.Live
+            1 -> LibraryTab.Vod
+            else -> LibraryTab.Series
+        }
+    }
 
     val currentProfileId by store.currentProfileId.collectAsStateWithLifecycle(initialValue = -1L)
     var isKid by remember { mutableStateOf(false) }
@@ -427,6 +435,21 @@ fun StartScreen(
                 navController.navigateTopLevel("library?q=&qs=")
             }
         },
+        libraryNav = LibraryNavConfig(
+            selected = headerLibraryTab,
+            onSelect = { tab ->
+                val idx = when (tab) {
+                    LibraryTab.Live -> 0
+                    LibraryTab.Vod -> 1
+                    LibraryTab.Series -> 2
+                }
+                scope.launch { store.setLibraryTabIndex(idx) }
+                val current = navController.currentBackStackEntry?.destination?.route
+                if (current != "library?q={q}&qs={qs}") {
+                    navController.navigateTopLevel("library?q=&qs=")
+                }
+            }
+        ),
         preferSettingsFirstFocus = preferSettingsFocus
     ) { pads: PaddingValues ->
         // TV-only: if Start is empty, auto-expand chrome once and focus Settings for immediate access.


### PR DESCRIPTION
## Summary
- wire StartScreen into HomeChrome's LibraryNavConfig so the header always renders the Live/VOD/Series shortcuts on phone and TV
- update CHANGELOG and ROADMAP entries to reflect the restored chrome behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f521ba58b88322bdcde31375ceec79