### PR TITLE
Improve Telegram backfill and settings orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,10 @@ Recent
   2.0. Flow-Debounces importieren aus `kotlinx.coroutines.flow`, der Telegram
   Chat-Picker ist als `@Composable` markiert und `TgSmsConsentManager` kapselt
   seinen `SupervisorJob` intern.
+- Maintenance 2025-11-09: Telegram-Settings nutzen einen eigenen
+  `TelegramSettingsViewModel` (Chat-Auflösung, Sync-Triggers, Snackbar). TDLib
+  Backfill korrigiert `fromId`/Offset, `TelegramMediaMapper` blockiert nicht mehr
+  auf dem Main-Thread und die Heuristiken normalisieren Release-Namen (inkl. Tests).
 - Telegram Build Guard: Kotlin 2.0 Release-Builds benötigen im Indexer weiterhin `Int`-basierte ID-Mengen und einen TDLib-Schreibpfad, der konkrete `IndexedMessageOutcome` zurückliefert. Die Fixes sind angewendet; Set<Long>/Result-Mismatches dürfen nicht wieder eingeführt werden, sonst scheitert `:app:compileReleaseKotlin`.
 - TV low-spec tuning (7a/TV): TV devices (detected via UiMode/Leanback/Fire TV) use a reduced-focus profile and smaller paging windows to improve smoothness on low-spec hardware. Focus effects drop shadowElevation; scales reduce to ~1.03. OkHttp dispatcher is throttled (maxRequests=16, perHost=4). Coil crossfades are disabled on TV to lower overdraw.
 - TV/DPAD focus (gate): ProfileGate tiles now use `tvClickable` + `tvFocusableItem` within a `focusGroup()` container, with a guarded initial `FocusRequester`. On TV, the first profile tile is highlighted immediately; DPAD navigation shows halo/scale.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1171,3 +1171,18 @@ Status: zu testen durch Nutzer
 - roadmap: Add Tiles/Rows Centralization (ON). Mark FocusKit Migration as dependent on this centralization.
 2025-10-07
 - docs(centralization): Deep-docs sweep to align with new Fish* layout. Marked legacy Cards v1 (PosterCard/ChannelCard/SeasonCard/EpisodeRow) as deprecated/replaced, removed guidance that suggested building tiles/focus per-screen, and documented FishTheme/FishTile/FishRow/FishContent (+ FishMeta/FishActions/FishLogging/FishResumeTile) as the single source of truth. Updated media_actions, detail_scaffold, tv_forms, playback_launcher to reference Fish* where relevant. Roadmap now blocks FocusKit finalization on completing Tiles/Rows centralization.
+2025-11-08
+- fix(telegram/service): korrigiert die Backfill-Paginierung (Offset-Clamping,
+  `fromId`-Step) damit Grenzfälle keine Nachrichten überspringen oder doppelt
+  abholen.
+- feat(telegram/parser): normalisiert Release-Namen robuster (Jahr, Sprache,
+  Qualities) und erweitert die Episoden-Heuristiken; neue Unit-Tests decken
+  die wichtigsten Schreibweisen ab.
+- fix(telegram/media): blockierende Thumbnail-Auflösung läuft nur noch off-main
+  und nutzt einen frühen Main-Thread-Guard.
+- fix(telegram/auth): zentraler Authorization-Gate + Mutex verhindern parallele
+  Login-Calls und TDLib-401/"another authorization"-Fehler.
+- refactor(settings/telegram): eigener `TelegramSettingsViewModel` kümmert sich
+  um Chat-Namen, Sync-Triggers und Snackbar-Effekte, was die UI-Komposition
+  spürbar entlastet.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@ Hinweis
 - Maintenance 2025-11-07: Release-Minify bindet jetzt `slf4j-android`, damit Junrar
   im R8-Schritt keinen `StaticLoggerBinder`-Fehler mehr auslöst.
 - Maintenance 2025-11-08: Telegram-Series Aggregation nutzt nun Chat-Titel als Fallback, normalisiert Seriennamen und sortiert Episoden nach Staffel/Episode/Datum. VOD-Heuristiken reinigen Filmtitel und speichern Jahresangaben in ObjectBox.
+- Maintenance 2025-11-09: Backfill-Paginierung im Telegram-Service korrigiert (Offset/`fromId`), Heuristiken erweitert (Range, Sprache, Jahr) samt Unit-Tests, Poster-Resolver blockiert nicht mehr den Main-Thread und Settings nutzen einen `TelegramSettingsViewModel` für Sync/Chat-Resolve.
 - Maintenance 2025-11-07: Start-Header blendet die Live/VOD/Serien-Schalter wieder
   direkt im HomeChrome ein (LibraryNavConfig auf Start), sodass Telefon- und TV-UIs
   die Bibliotheksnavigation oben neben Suche/Profil/Einstellungen anzeigen.

--- a/app/src/main/java/com/chris/m3usuite/telegram/service/TelegramTdlibService.kt
+++ b/app/src/main/java/com/chris/m3usuite/telegram/service/TelegramTdlibService.kt
@@ -982,7 +982,11 @@ class TelegramTdlibService : Service() {
         fun backoffMs(a: Int): Long = (500 * 2.0.pow(a.coerceAtMost(6))).toLong()
 
         while (keepGoing) {
-            val offset = if (fromId == 0L) 0 else -1
+            val offset = if (fromId == 0L) {
+                0
+            } else {
+                (-pageSize).coerceAtLeast(-99)
+            }
             val fn = TdLibReflection.buildGetChatHistory(chatId, fromId, offset, pageSize, false) ?: break
             val result = TdLibReflection.sendForResultDetailed(
                 ch,
@@ -1043,7 +1047,7 @@ class TelegramTdlibService : Service() {
             }
 
             attempt = 0
-            fromId = nextFromId
+            fromId = if (nextFromId > 0L) nextFromId - 1 else nextFromId
             keepGoing = fetchAll
         }
         android.util.Log.i("TdSvc", "backfill done chatId=${chatId} processed=${processed} newVod=${newVod} newSeriesEpisodes=${newSeriesEpisodes}")

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/TelegramSettingsViewModel.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/TelegramSettingsViewModel.kt
@@ -1,0 +1,174 @@
+package com.chris.m3usuite.ui.screens
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.chris.m3usuite.BuildConfig
+import com.chris.m3usuite.prefs.SettingsStore
+import com.chris.m3usuite.telegram.service.TelegramServiceClient
+import com.chris.m3usuite.work.TelegramSyncWorker
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+class TelegramSettingsViewModel(
+    application: Application,
+    private val store: SettingsStore
+) : AndroidViewModel(application) {
+
+    data class UiState(
+        val enabled: Boolean = false,
+        val selectedChats: Set<Long> = emptySet(),
+        val resolvedSelectionLabel: String? = null,
+        val isResolvingSelection: Boolean = false,
+        val resendSeconds: Int = 0
+    )
+
+    sealed interface Effect {
+        data class Snackbar(val message: String) : Effect
+    }
+
+    private val serviceClient = TelegramServiceClient(application)
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+    private val _effects = Channel<Effect>(Channel.BUFFERED)
+    val effects = _effects.receiveAsFlow()
+    private val currentApiId = AtomicReference(BuildConfig.TG_API_ID)
+    private val currentApiHash = AtomicReference(BuildConfig.TG_API_HASH)
+
+    private var resolveJob: kotlinx.coroutines.Job? = null
+
+    init {
+        serviceClient.bind()
+        viewModelScope.launch {
+            store.tgEnabled.collect { enabled ->
+                _uiState.update { it.copy(enabled = enabled) }
+                triggerSelectionResolve(enabled, _uiState.value.selectedChats)
+            }
+        }
+        viewModelScope.launch {
+            store.tgSelectedChatsCsv.collect { csv ->
+                val ids = csv.split(',').mapNotNull { it.trim().toLongOrNull() }.toSet()
+                _uiState.update { it.copy(selectedChats = ids) }
+                triggerSelectionResolve(_uiState.value.enabled, ids)
+            }
+        }
+        viewModelScope.launch {
+            store.tgApiId.collect { override ->
+                val resolved = if (override > 0) override else BuildConfig.TG_API_ID
+                currentApiId.set(resolved)
+            }
+        }
+        viewModelScope.launch {
+            store.tgApiHash.collect { override ->
+                val resolved = if (override.isNotBlank()) override else BuildConfig.TG_API_HASH
+                currentApiHash.set(resolved)
+            }
+        }
+        viewModelScope.launch {
+            serviceClient.resendInSec.collect { seconds ->
+                _uiState.update { it.copy(resendSeconds = seconds) }
+            }
+        }
+    }
+
+    private fun triggerSelectionResolve(enabled: Boolean, ids: Set<Long>) {
+        resolveJob?.cancel()
+        if (!enabled || ids.isEmpty()) {
+            _uiState.update { it.copy(resolvedSelectionLabel = null, isResolvingSelection = false) }
+            return
+        }
+        resolveJob = viewModelScope.launch(Dispatchers.IO) {
+            _uiState.update { it.copy(isResolvingSelection = true) }
+            val label = resolveChatNames(ids)
+            _uiState.update { it.copy(resolvedSelectionLabel = label, isResolvingSelection = false) }
+        }
+    }
+
+    private suspend fun resolveChatNames(ids: Set<Long>): String? = withContext(Dispatchers.IO) {
+        if (ids.isEmpty()) return@withContext null
+        val sorted = ids.sorted()
+        runCatching {
+            ensureClientReady()
+            val ready = withTimeoutOrNull(5_000) {
+                serviceClient.awaitAuthorized()
+                true
+            } ?: false
+            if (!ready) return@runCatching sorted.joinToString(", ") { it.toString() }
+            val resolved = serviceClient.resolveChatTitles(sorted.toLongArray())
+            if (resolved.isNotEmpty()) {
+                resolved.joinToString(", ") { it.second }
+            } else {
+                sorted.joinToString(", ") { it.toString() }
+            }
+        }.getOrElse {
+            sorted.joinToString(", ") { it.toString() }
+        }
+    }
+
+    private suspend fun ensureClientReady() {
+        val apiId = currentApiId.get()
+        val apiHash = currentApiHash.get()
+        if (apiId <= 0 || apiHash.isBlank()) return
+        serviceClient.start(apiId, apiHash)
+        serviceClient.getAuth()
+    }
+
+    fun onIntent(intent: Intent) {
+        when (intent) {
+            is Intent.ConfirmChats -> viewModelScope.launch {
+                val csv = intent.chatIds.sorted().joinToString(",")
+                store.setTelegramSelectedChatsCsv(csv)
+                scheduleSync()
+                _effects.send(Effect.Snackbar("Telegram Sync gestartet"))
+            }
+            Intent.RequestSync -> viewModelScope.launch { scheduleSync() }
+            is Intent.Snackbar -> viewModelScope.launch { _effects.send(Effect.Snackbar(intent.message)) }
+        }
+    }
+
+    private suspend fun scheduleSync() {
+        TelegramSyncWorker.scheduleNow(
+            getApplication(),
+            mode = TelegramSyncWorker.MODE_ALL,
+            refreshHome = true
+        )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        resolveJob?.cancel()
+        serviceClient.unbind()
+    }
+
+    sealed interface Intent {
+        data class ConfirmChats(val chatIds: Set<Long>) : Intent
+        object RequestSync : Intent
+        data class Snackbar(val message: String) : Intent
+    }
+
+    class Factory(
+        private val application: Application,
+        private val store: SettingsStore
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(TelegramSettingsViewModel::class.java)) {
+                return TelegramSettingsViewModel(application, store) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+        }
+    }
+}

--- a/app/src/test/java/com/chris/m3usuite/telegram/TelegramHeuristicsTest.kt
+++ b/app/src/test/java/com/chris/m3usuite/telegram/TelegramHeuristicsTest.kt
@@ -1,0 +1,49 @@
+package com.chris.m3usuite.telegram
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TelegramHeuristicsTest {
+    @Test
+    fun `parse handles german season format`() {
+        val caption = "MeineSerie S02E05 – Der Plan (2021) [GER] 1080p"
+        val result = TelegramHeuristics.parse(caption)
+
+        assertTrue(result.isSeries)
+        assertEquals("MeineSerie", result.seriesTitle)
+        assertEquals(2, result.season)
+        assertEquals(5, result.episode)
+        assertNull(result.episodeEnd)
+        assertEquals("Der Plan", result.title)
+        assertEquals("de", result.language)
+        assertEquals(2021, result.year)
+    }
+
+    @Test
+    fun `parse handles range notation`() {
+        val caption = "Serie 1x03-05 ENG"
+        val result = TelegramHeuristics.parse(caption)
+
+        assertTrue(result.isSeries)
+        assertEquals("Serie", result.seriesTitle)
+        assertEquals(1, result.season)
+        assertEquals(3, result.episode)
+        assertEquals(5, result.episodeEnd)
+        assertNull(result.title)
+        assertEquals("en", result.language)
+        assertNull(result.year)
+    }
+
+    @Test
+    fun `parse cleans movie metadata`() {
+        val caption = "Großer Film 2020 GER 1080p x265"
+        val result = TelegramHeuristics.parse(caption)
+
+        assertTrue(!result.isSeries)
+        assertEquals("Großer Film", result.title)
+        assertEquals("de", result.language)
+        assertEquals(2020, result.year)
+    }
+}


### PR DESCRIPTION
## Summary
- fix Telegram backfill pagination to clamp offsets and advance fromId correctly
- harden Telegram caption heuristics, normalise release tokens, and add unit tests
- guard Telegram poster resolution off the main thread and gate TDLib auth commands behind awaitAuthorized
- introduce a TelegramSettingsViewModel to resolve chat names, trigger syncs, and surface snackbar effects

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f650b8396c8322a475ddccbbbd4001