### PR TITLE
Fix StartScreen imports for release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2025-11-12
+- fix(main): Import StartScreen and ProfileManagerScreen in MainActivity so
+  release builds resolve the new package locations.
+
 2025-11-11
 - fix(telegram/repo): Selected chat IDs now come from the unified
   `tgSelectedChatsCsv` list for both VOD and series flows, leaving the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,8 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-12: MainActivity imports StartScreen/ProfileManagerScreen
+  from their ui.home/ui.profile packages so release builds compile again.
 - Maintenance 2025-11-11: Telegram-Import nutzt eine gemeinsame Chat-Selektion,
   erkennt HLS-/Octet-MIMEs zuverlässiger und meldet Sync-Trigger jetzt als
   Snackbar-Effekt aus dem ViewModel.

--- a/app/src/main/java/com/chris/m3usuite/MainActivity.kt
+++ b/app/src/main/java/com/chris/m3usuite/MainActivity.kt
@@ -26,9 +26,11 @@ import com.chris.m3usuite.prefs.SettingsStore
 import com.chris.m3usuite.ui.auth.ProfileGate
 import com.chris.m3usuite.ui.home.LocalMiniPlayerResume
 import com.chris.m3usuite.ui.home.MiniPlayerState
+import com.chris.m3usuite.ui.home.StartScreen
 import com.chris.m3usuite.ui.home.buildRoute
 import com.chris.m3usuite.ui.screens.*
 import com.chris.m3usuite.ui.theme.AppTheme
+import com.chris.m3usuite.ui.profile.ProfileManagerScreen
 import com.chris.m3usuite.work.XtreamDeltaImportWorker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first


### PR DESCRIPTION
## Summary
- import StartScreen and ProfileManagerScreen in MainActivity so the navigation graph resolves after the package move
- document the maintenance fix in CHANGELOG and ROADMAP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7e159efd08322b00410abf493da59