### PR TITLE
Fix Telegram release build regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2025-11-15
+- fix(player/telegram): Treat `C.LENGTH_UNSET` as a `Long` when deriving
+  Telegram random-access ranges so release builds compare like types again.
+- fix(ui/telegram): Precompute the play action label so the Telegram detail
+  screen no longer calls `stringResource` from a non-composable context.
+
 2025-11-14
 - fix(telegram/detail): Add a dedicated Telegram detail screen and refresh the
   TDLib repository helpers (global search/message lookup, poster extraction)

--- a/app/src/main/java/com/chris/m3usuite/player/datasource/TdlibRandomAccessSource.kt
+++ b/app/src/main/java/com/chris/m3usuite/player/datasource/TdlibRandomAccessSource.kt
@@ -56,7 +56,8 @@ class TdlibRandomAccessSource(
         val file = runBlockingIo { service.getFile(fileId) }
         length = file.size.toLong()
         position = if (dataSpec.position >= 0) dataSpec.position else 0L
-        bytesRemaining = if (dataSpec.length == C.LENGTH_UNSET) {
+        val lengthUnset = C.LENGTH_UNSET.toLong()
+        bytesRemaining = if (dataSpec.length == lengthUnset) {
             if (length > 0) length - position else -1L
         } else dataSpec.length
 
@@ -67,7 +68,7 @@ class TdlibRandomAccessSource(
         triggerDownload(position, max(chunkSize, bytesRemaining.takeIf { it > 0 } ?: readahead))
 
         opened = true
-        return if (dataSpec.length == C.LENGTH_UNSET) length else dataSpec.length
+        return if (dataSpec.length == lengthUnset) length else dataSpec.length
     }
 
     @Throws(IOException::class)

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/TelegramVideoDetailScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/TelegramVideoDetailScreen.kt
@@ -65,11 +65,12 @@ fun TelegramVideoDetailScreen(
         loading = false
     }
 
-    val playAction = remember(media) {
+    val playLabel = stringResource(R.string.action_play)
+    val playAction = remember(media, playLabel) {
         media?.let { item ->
             MediaAction(
                 id = MediaActionId.Play,
-                label = stringResource(R.string.action_play),
+                label = playLabel,
                 primary = true,
                 onClick = {
                     scope.launch {


### PR DESCRIPTION
## Summary
- treat Media3's `C.LENGTH_UNSET` as a `Long` in the Telegram random access source to restore release builds
- precompute the Telegram detail play label so the screen no longer calls `stringResource` from outside a composable
- document the release build fixes in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff0ae47a608322a0b7764f7f785e02