### PR TITLE
Fix: Stabilize TG prefetch against dispose (no more crash when leaving Settings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2025-11-16
+- fix(ui/telegram): Guard Start row prefetchers against disposal races so
+  leaving Settings or switching routes no longer crashes the Telegram rows.
+- fix(ui/rows): Make the paged row prefetch collector cancellation-safe and
+  non-fatal, preventing crashes when list states dispose mid-collection.
+
 2025-11-15
 - fix(player/telegram): Treat `C.LENGTH_UNSET` as a `Long` when deriving
   Telegram random-access ranges so release builds compare like types again.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,8 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-16: Telegram Start/FishRow prefetcher guards prevent
+  disposal races so leaving Settings or switching tabs stops crashing Start.
 - Maintenance 2025-11-13: Telegram-Settings zeigen wieder Proxy- und
   Auto-Download-Karten; `KeyboardOptions` kommt aus `foundation.text`, damit
   Release-Builds mit Kotlin 2.0 erneut durchlaufen.


### PR DESCRIPTION
## Summary
- guard the Start screen telegram prefetcher against cancellation, bounds issues, and missing posters before firing coil requests
- make the paged row prefetch collector cancellation-safe and non-fatal so disposing a list no longer crashes
- document the telegram prefetch stabilization in the changelog and roadmap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff46263e888322a98870cfc9dbcabc