### PR TITLE
MirrorMode: apply TDLib log verbosity slider value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-17
+- fix(settings/telegram): Ensure the TDLib log verbosity slider updates the
+  mirror-mode auth repository so log level changes apply even when the background
+  service is idle.
+
 2025-11-16
 - fix(ui/telegram): Guard Start row prefetchers against disposal races so
   leaving Settings or switching routes no longer crashes the Telegram rows.


### PR DESCRIPTION
## Summary
- ensure Telegram settings reuse a cached TelegramAuthRepository for log verbosity updates
- propagate slider changes to TDLib even when only the mirror-mode auth bridge is active
- document the fix in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff4b5ade248322af5c55fefde01778