### PR TITLE
feat(ci): generate and upload TDLib Java bindings

### DIFF
--- a/.github/workflows/Standart.yml
+++ b/.github/workflows/Standart.yml
@@ -62,7 +62,7 @@ jobs:
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get update -qq
-          sudo apt-get install -y ninja-build cmake git curl unzip tar zstd openjdk-17-jdk gperf file python3 build-essential
+          sudo apt-get install -y ninja-build cmake git curl unzip tar zstd openjdk-17-jdk gperf file python3 php-cli build-essential
           echo "JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))" >> $GITHUB_ENV
 
       - name: Cache NDK ${{ env.NDK_VERSION }}
@@ -258,6 +258,35 @@ jobs:
             -DTD_ENABLE_TESTS=OFF
           cmake --build "$HOST_BUILD_DIR" --target prepare_cross_compiling -- -j 2
 
+      - name: Generate TDLib Java bindings (host)
+        if: matrix.abi == 'arm64-v8a'
+        run: |
+          set -euo pipefail
+          HOST_BUILD_DIR="build-host"
+          BIN_DIR="$HOST_BUILD_DIR/td/bin"
+          JAVA_OUT_DIR="$HOST_BUILD_DIR/java-bindings"
+          PACKAGE_PATH="org/drinkless/tdlib"
+
+          cmake --build "$HOST_BUILD_DIR" --target td_generate_java_api -- -j 2
+
+          GEN_BIN="$BIN_DIR/td_generate_java_api"
+          TLO_FILE="$BIN_DIR/td/generate/scheme/td_api.tlo"
+          TL_FILE="$BIN_DIR/td/generate/scheme/td_api.tl"
+
+          test -x "$GEN_BIN" || { echo "::error ::td_generate_java_api is missing"; exit 60; }
+          test -f "$TLO_FILE" || { echo "::error ::td_api.tlo not found"; exit 61; }
+
+          mkdir -p "$JAVA_OUT_DIR"
+          "$GEN_BIN" TdApi "$TLO_FILE" "$JAVA_OUT_DIR" "$PACKAGE_PATH"
+
+          if command -v php >/dev/null 2>&1 && [ -f "$TL_FILE" ] && [ -f "$BIN_DIR/td/generate/JavadocTlDocumentationGenerator.php" ]; then
+            php "$BIN_DIR/td/generate/JavadocTlDocumentationGenerator.php" "$TL_FILE" "$JAVA_OUT_DIR/$PACKAGE_PATH/TdApi.java"
+          else
+            echo "::notice ::Skipping TdApi Javadoc generation (php or generator script missing)"
+          fi
+
+          find "$JAVA_OUT_DIR" -type f -name '*.java' -print | sed 's/^/  /'
+
       - name: Validate prebuilt or fallback BoringSSL ABI (${{ matrix.abi }})
         run: |
           set -Eeuo pipefail
@@ -436,5 +465,14 @@ jobs:
         with:
           name: tdlib-android-${{ matrix.abi }}-boringssl
           path: build-${{ matrix.abi }}/install/
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload TDLib Java bindings
+        if: success() && matrix.abi == 'arm64-v8a'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tdlib-java-bindings
+          path: build-host/java-bindings/
           if-no-files-found: error
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-19
+- chore(ci): Standart workflow now generates the TDLib Java bindings and
+  publishes them as a dedicated artifact so TdApi.java accompanies the
+  prebuilt `.so` libraries.
+
 2025-11-18
 - fix(ci): Teach `Standart.yml` to install native build tools and run a host
   `prepare_cross_compiling` pass so TDLib TL auto-sources exist before the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,10 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-19: CI Standart workflow erzeugt jetzt die TDLib-Java-
+  Bindings (`TdApi.java`) und lädt sie als separates Artefakt hoch, damit die
+  Android-Pipeline neben den `.so`-Bibliotheken auch die Java-API konsumieren
+  kann.
 - Maintenance 2025-11-18: CI Standart workflow führt vor den Android-Matrix-
   Builds einen nativen `prepare_cross_compiling`-Lauf aus und installiert die
   fehlenden Host-Build-Tools, damit die TL-Autoquellen rechtzeitig entstehen


### PR DESCRIPTION
## Summary
- install php-cli in the CI image so the TDLib Java documentation step can run
- build the td_generate_java_api helper during the host pass and invoke it to emit TdApi.java
- upload the generated Java bindings alongside the native artifacts to make them downloadable from CI

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f79ea0a48322b14c37c3153e4758)