### PR TITLE
Fix BoringSSL fallback handling in Standart workflow

### DIFF
--- a/.github/workflows/Standart.yml
+++ b/.github/workflows/Standart.yml
@@ -200,8 +200,14 @@ jobs:
           COMMIT="$(printf '%s\n' "$BORINGSSL_TAG" | sed -E 's/^boringssl-([0-9a-fA-F]+)-.*/\1/')"
           if [ -n "$COMMIT" ]; then
             cd bssl-src
-            git fetch --depth=1 origin $COMMIT || git fetch origin $COMMIT
-            git checkout $COMMIT || { echo "::warning ::Could not checkout $COMMIT, using HEAD"; }
+            if git cat-file -e "$COMMIT^{commit}" 2>/dev/null; then
+              git checkout "$COMMIT"
+            elif git fetch --depth=1 origin "$COMMIT" || git fetch origin "$COMMIT"; then
+              git checkout "$COMMIT"
+            else
+              echo "::warning ::Could not resolve BoringSSL commit $COMMIT from $BORINGSSL_TAG; building from repository HEAD instead"
+            fi
+            echo "::notice ::BoringSSL source commit -> $(git rev-parse HEAD)"
             cd ..
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,11 @@ Codex – Operating Rules (override)
 - CI guard: `.github/workflows/Standart.yml` führt vor den Android-Matrix-Builds
   einen nativen Host-Lauf (`prepare_cross_compiling`) aus und benötigt die
   systemseitigen Build-Essentials. Beim Anpassen des Workflows darf dieser
-  Schritt nicht entfallen, sonst fehlen TL-Autoquellen und Artefakte.
+  Schritt nicht entfallen, sonst fehlen TL-Autoquellen und Artefakte. Fehlt
+  der in `BORINGSSL_TAG` referenzierte Commit upstream, fällt der Fallback-Build
+  jetzt automatisch auf den aktuellen BoringSSL-HEAD zurück – bitte das Logging
+  im Step "Fallback - build BoringSSL" beibehalten, damit der aktive Commit im
+  Artefakt-Log ersichtlich bleibt.
 - TV focus/DPAD audit: `tools/audit_tv_focus.sh` enforces rules (TvFocusRow for horizontal containers, tvClickable for interactives, no ad‑hoc DPAD). Wired into CI (`.github/workflows/ci.yml`) and fails PRs on violations.
 - Central facade: Use `com.chris.m3usuite.ui.focus.FocusKit` as the single entry point for focus across all UIs (TV/phone/tablet). It provides primitives (`tvClickable`, `tvFocusFrame`, `tvFocusableItem`, `focusGroup`, `focusBringIntoViewOnFocus`), unified row wrappers (`TvRowLight` → `TvFocusRow`, `TvRowMedia`/`TvRowPaged` → FocusKit’s row engine), DPAD helpers (`onDpadAdjustLeftRight/UpDown`), grid neighbors (`focusNeighbors`), and re‑exports of `TvButton`/`TvTextButton`/`TvOutlinedButton`/`TvIconButton`). Avoid importing row engines or skin primitives directly in screens.
 

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -88,7 +88,10 @@ Dieses Dokument bietet den vollständigen, detaillierten Überblick über Module
   50–200-MiB-Ringbuffer im Cache-Verzeichnis.
 - Build: `TG_API_ID`/`TG_API_HASH` als BuildConfig via sichere Lookup‑Kette (ohne Secrets im Repo). Reihenfolge: ENV → `/.tg.secrets.properties` (root, untracked) → `-P` Gradle‑Props → Default 0/leer. Runtime‑Fallback: Ist BuildConfig leer, liest der app‑seitige TDLib‑Client (Player‑DataSource) die Keys aus den Settings (`tg_api_id`, `tg_api_hash`). Packaging: TDLib (arm64‑v8a), ProGuard‑Keep für `org.drinkless.td.libcore.telegram.**`. Die JNI‑Lib `libtdjni.so` wird durch einen statischen Initializer in `org.drinkless.tdlib.Client` automatisch geladen.
 - Packaging: `:libtd` Android‑Library mit `jniLibs` (`arm64-v8a/libtdjni.so`). App hängt an `:libtd`, sodass TDLib zur Laufzeit vorhanden ist; BuildConfig `TG_API_ID`/`TG_API_HASH` kommen aus `gradle.properties`.
-- Build TDLib/JNI: Single‑ABI arm64‑v8a wird mit statisch gelinktem BoringSSL gebaut und ins Modul kopiert.
+- Build TDLib/JNI: Single‑ABI arm64‑v8a wird mit statisch gelinktem BoringSSL gebaut und ins Modul kopiert. Scheitert der in
+  `.github/workflows/Standart.yml` konfigurierte `BORINGSSL_TAG` beim Fetch,
+  setzt der Workflow den Fallback automatisch auf den aktuellen BoringSSL-HEAD
+  und protokolliert den tatsächlichen Commit im Artefakt-Log.
   - arm64: `scripts/tdlib-build-arm64.sh` (Phase‑2: LTO/GC‑sections/strip‑unneeded zur Größenreduktion)
  - Cache: `TelegramCacheCleanupWorker` trimmt lokale TD‑Dateien täglich auf `TG_CACHE_LIMIT_GB` (GB) – best‑effort Datei‑System‑Trim.
  - Reflection: `TdLibReflection.extractBestPhotoSizeFileId(...)` liefert die größte Photo-Größe als File-ID; `extractThumbFileId(...)` nutzt das gleiche Hilfswerk. `TgGate` fällt ohne BuildConfig-Override standardmäßig auf Mirror-Only (`false`) zurück, sodass OBX erst nach explizitem Opt-In aktiviert wird.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-20
+- fix(ci): Make the Standart workflow resilient when the pinned BoringSSL
+  commit is missing from upstream so fallback builds continue and `.so`
+  artifacts stay available.
+
 2025-11-19
 - chore(ci): Standart workflow now generates the TDLib Java bindings and
   publishes them as a dedicated artifact so TdApi.java accompanies the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-20: Standart-Workflow fällt bei fehlendem BoringSSL-
+  Commit sauber auf den aktuellen HEAD zurück, sodass die `.so`-Artefakte
+  weiterhin gebaut werden.
 - Maintenance 2025-11-19: CI Standart workflow erzeugt jetzt die TDLib-Java-
   Bindings (`TdApi.java`) und lädt sie als separates Artefakt hoch, damit die
   Android-Pipeline neben den `.so`-Bibliotheken auch die Java-API konsumieren


### PR DESCRIPTION
## Summary
- make the Standart workflow tolerate missing BORINGSSL_TAG commits by falling back to the current BoringSSL HEAD and logging the resolved revision
- document the adjusted CI behavior across AGENTS.md, the architecture overview, the changelog, and the roadmap

## Testing
- `bash -lc 'set -euo pipefail; rm -rf tmp-bssl; mkdir tmp-bssl; cd tmp-bssl; git clone --depth=1 https://boringssl.googlesource.com/boringssl bssl-src; COMMIT=$(printf "%s\n" "$BORINGSSL_TAG" | sed -E "s/^boringssl-([0-9a-fA-F]+)-.*/\1/"); if [ -n "$COMMIT" ]; then cd bssl-src; if git cat-file -e "$COMMIT^{commit}" 2>/dev/null; then git checkout "$COMMIT"; elif git fetch --depth=1 origin "$COMMIT" || git fetch origin "$COMMIT"; then git checkout "$COMMIT"; else echo "::warning ::Could not resolve BoringSSL commit $COMMIT from $BORINGSSL_TAG; building from repository HEAD instead"; fi; echo "::notice ::BoringSSL source commit -> $(git rev-parse HEAD)"; fi'`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912fb755df483229d50a35ed855c664)