### PR TITLE
Fix Standart workflow log artifact collection

### DIFF
--- a/.github/workflows/Standart.yml
+++ b/.github/workflows/Standart.yml
@@ -518,6 +518,27 @@ jobs:
           set -e
           exit $rc
 
+      - name: Collect configure diagnostics (${{ matrix.abi }})
+        if: always()
+        run: |
+          set -euo pipefail
+          ABI="${{ matrix.abi }}"
+          SRC_DIR="build-${ABI}/CMakeFiles"
+          DEST_DIR="logs-${ABI}"
+          mkdir -p "$DEST_DIR"
+
+          if [ -d "$SRC_DIR" ]; then
+            for f in CMakeError.log CMakeOutput.log; do
+              if [ -f "$SRC_DIR/$f" ]; then
+                cp "$SRC_DIR/$f" "$DEST_DIR/$f"
+              else
+                echo "::notice ::$SRC_DIR/$f missing"
+              fi
+            done
+          else
+            echo "::notice ::$SRC_DIR missing"
+          fi
+
       - name: Build TDLib with Ninja (${{ matrix.abi }})
         run: |
           set -euo pipefail
@@ -566,10 +587,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.abi }}
-          path: |
-            logs-${{ matrix.abi }}/
-            build-${{ matrix.abi }}/CMakeFiles/CMakeError.log
-            build-${{ matrix.abi }}/CMakeFiles/CMakeOutput.log
+          path: logs-${{ matrix.abi }}/
           if-no-files-found: warn
           retention-days: 14
 

--- a/ARCHITECTURE_OVERVIEW.md
+++ b/ARCHITECTURE_OVERVIEW.md
@@ -92,6 +92,9 @@ Dieses Dokument bietet den vollständigen, detaillierten Überblick über Module
   `.github/workflows/Standart.yml` konfigurierte `BORINGSSL_TAG` beim Fetch,
   setzt der Workflow den Fallback automatisch auf den aktuellen BoringSSL-HEAD
   und protokolliert den tatsächlichen Commit im Artefakt-Log.
+  - Logs: Die Workflow-Stufe bündelt alle Build-/Konfig-Logs in `logs-<abi>`
+    (inkl. CMakeError/Output), bevor `actions/upload-artifact` läuft, damit das
+    Logs-Artefakt auch ohne optionale Dateien zuverlässig entsteht.
   - arm64: `scripts/tdlib-build-arm64.sh` (Phase‑2: LTO/GC‑sections/strip‑unneeded zur Größenreduktion)
  - Cache: `TelegramCacheCleanupWorker` trimmt lokale TD‑Dateien täglich auf `TG_CACHE_LIMIT_GB` (GB) – best‑effort Datei‑System‑Trim.
  - Reflection: `TdLibReflection.extractBestPhotoSizeFileId(...)` liefert die größte Photo-Größe als File-ID; `extractThumbFileId(...)` nutzt das gleiche Hilfswerk. `TgGate` fällt ohne BuildConfig-Override standardmäßig auf Mirror-Only (`false`) zurück, sodass OBX erst nach explizitem Opt-In aktiviert wird.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-22
+- fix(ci): Collect CMake configure logs inside the Standart workflow's
+  logs bundle and upload only that directory so log artifacts are always
+  published even when CMake's optional files are absent.
+
 2025-11-21
 - fix(ci): Teach Standart TDLib build to run the new gperf-based tdutils
   generator on the host so `mime_type_to_extension.cpp` exists before the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-22: Standart-Workflow sammelt die CMake-Konfig-
+  Logs vor dem Upload ins Logs-Bundle, damit das Artefakt auch ohne
+  optionale CMake-Dateien entsteht.
 - Maintenance 2025-11-21: Standart-Workflow baut die tdutils MIME-Autos mit
   dem neuen gperf-Generator vor dem Android-Matrix-Lauf, damit TDLib auch nach
   Upstream-Änderungen fehlerfrei für arm64/v7a kompiliert.


### PR DESCRIPTION
## Summary
- ensure the Standart TDLib workflow copies CMake configure logs into the logs bundle and uploads only that directory
- document the workflow change in the changelog, roadmap, and architecture overview

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69132be983bc83228afb817225af9020)