### PR TITLE
Fix Standart tdutils MIME pre-generation gating

### DIFF
--- a/.github/workflows/Standart.yml
+++ b/.github/workflows/Standart.yml
@@ -237,7 +237,9 @@ jobs:
             command -v gperf >/dev/null 2>&1 || { echo "::error ::gperf missing for tdutils auto generation"; exit 93; }
             mkdir -p "$gen_dir/auto"
             build_dir="$PWD/.tdmime-host"
-            cmake -G Ninja -S "$gen_dir" -B "$build_dir" -DCMAKE_BUILD_TYPE=Release
+            cmake -G Ninja -S "$gen_dir" -B "$build_dir" \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DTDUTILS_MIME_TYPE=ON
             cmake --build "$build_dir" --target tdmime_auto -- -j 2
           else
             echo "::notice ::No tdutils MIME generator detected; relying on CMake custom commands."
@@ -394,7 +396,9 @@ jobs:
               command -v gperf >/dev/null 2>&1 || { echo "::warning ::gperf unavailable; tdutils auto files may be missing"; exit 0; }
               mkdir -p "$gen_dir/auto"
               build_dir="$PWD/.tdmime-host"
-              cmake -G Ninja -S "$gen_dir" -B "$build_dir" -DCMAKE_BUILD_TYPE=Release
+              cmake -G Ninja -S "$gen_dir" -B "$build_dir" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DTDUTILS_MIME_TYPE=ON
               cmake --build "$build_dir" --target tdmime_auto -- -j 2
             fi
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ Codex – Operating Rules (override)
   im Step "Fallback - build BoringSSL" beibehalten, damit der aktive Commit im
   Artefakt-Log ersichtlich bleibt. TDLib >1.8 nutzt einen gperf-basierten
   Generator (`generate_mime_types_gperf.cpp`) für `tdutils/generate/auto/*`; die
-  Standart-Workflow-Hosts müssen deshalb `gperf` installiert haben und den
-  `tdmime_auto`-Build (CMake/Ninja) vor dem Android-Matrix-Lauf ausführen, damit
-  `mime_type_to_extension.cpp` und `extension_to_mime_type.cpp` im Source-Tree
-  bereitstehen.
+  Standart-Workflow-Hosts müssen deshalb `gperf` installiert haben, beim CMake-
+  Aufruf `TDUTILS_MIME_TYPE=ON` setzen und den `tdmime_auto`-Build (CMake/Ninja)
+  vor dem Android-Matrix-Lauf ausführen, damit `mime_type_to_extension.cpp` und
+  `extension_to_mime_type.cpp` im Source-Tree bereitstehen.
 - TV focus/DPAD audit: `tools/audit_tv_focus.sh` enforces rules (TvFocusRow for horizontal containers, tvClickable for interactives, no ad‑hoc DPAD). Wired into CI (`.github/workflows/ci.yml`) and fails PRs on violations.
 - Central facade: Use `com.chris.m3usuite.ui.focus.FocusKit` as the single entry point for focus across all UIs (TV/phone/tablet). It provides primitives (`tvClickable`, `tvFocusFrame`, `tvFocusableItem`, `focusGroup`, `focusBringIntoViewOnFocus`), unified row wrappers (`TvRowLight` → `TvFocusRow`, `TvRowMedia`/`TvRowPaged` → FocusKit’s row engine), DPAD helpers (`onDpadAdjustLeftRight/UpDown`), grid neighbors (`focusNeighbors`), and re‑exports of `TvButton`/`TvTextButton`/`TvOutlinedButton`/`TvIconButton`). Avoid importing row engines or skin primitives directly in screens.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-23
+- fix(ci): Force the Standart workflow's tdutils pre-generation CMake run to
+  enable `TDUTILS_MIME_TYPE`, so the `tdmime_auto` target exists and gperf can
+  emit the MIME auto-sources before the Android matrix starts.
+
 2025-11-22
 - fix(ci): Collect CMake configure logs inside the Standart workflow's
   logs bundle and upload only that directory so log artifacts are always

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-23: Standart-Workflow setzt beim tdutils MIME-Generator
+  `TDUTILS_MIME_TYPE=ON`, damit die gperf-Targets (`tdmime_auto`) auf dem Host
+  entstehen und der Android-Matrix-Lauf wieder startet.
 - Maintenance 2025-11-22: Standart-Workflow sammelt die CMake-Konfig-
   Logs vor dem Upload ins Logs-Bundle, damit das Artefakt auch ohne
   optionale CMake-Dateien entsteht.


### PR DESCRIPTION
## Summary
- ensure the Standart tdutils MIME pre-generation passes TDUTILS_MIME_TYPE to expose the tdmime_auto target
- document the new requirement in AGENTS.md and sync the changelog/roadmap entries

## Testing
- /root/.local/share/mise/installs/go/1.24.3/bin/actionlint .github/workflows/Standart.yml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691330454e7c8322bc1e83474a2edb95)