### PR TITLE
fix(ci): generate td api auto sources on host

### DIFF
--- a/.github/workflows/Standart.yml
+++ b/.github/workflows/Standart.yml
@@ -405,6 +405,44 @@ jobs:
             echo "::notice ::No generator present; relying on CMake custom commands."
           fi
 
+      - name: Prepare TDLib TL auto sources on host
+        run: |
+          set -euo pipefail
+          HOST_BUILD_DIR="build-host"
+          cmake -G Ninja -S "${TD_SRC_DIR}" -B "$HOST_BUILD_DIR" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DTD_ENABLE_TESTS=OFF \
+            -DTD_ENABLE_JNI=OFF \
+            -DTD_ENABLE_JAVA=OFF
+
+          targets="$(ninja -C "$HOST_BUILD_DIR" -t targets || true)"
+          echo "::group::available host targets"
+          printf '%s\n' "$targets" | sed 's/^/  /'
+          echo "::endgroup::"
+
+          ran_target=false
+          for target in prepare_cross_compiling tl_generate_c generate_c; do
+            if printf '%s\n' "$targets" | grep -q "^${target}:"; then
+              cmake --build "$HOST_BUILD_DIR" --target "$target" -- -j 2
+              ran_target=true
+              break
+            fi
+          done
+
+          if [ "$ran_target" = false ]; then
+            echo "::notice ::prepare_cross_compiling target missing; running td_generate_java_api as best-effort fallback"
+            cmake --build "$HOST_BUILD_DIR" --target td_generate_java_api -- -j 2 || true
+          fi
+
+          TD_API_CPP="$(find "${TD_SRC_DIR}" -path '*/td/generate/auto/td/telegram/td_api_0.cpp' -print -quit || true)"
+          if [ -z "$TD_API_CPP" ]; then
+            echo "::group::debug-td-api-auto"
+            find "${TD_SRC_DIR}/td" -maxdepth 6 -path '*td_api*.cpp' -print || true
+            echo "::endgroup::"
+            echo "::error ::td_api_0.cpp missing after prepare_cross_compiling"
+            exit 94
+          fi
+
       - name: Validate prebuilt or fallback BoringSSL ABI (${{ matrix.abi }})
         run: |
           set -Eeuo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2025-11-24
+- fix(ci): Standart workflow runs a host `prepare_cross_compiling` pass to
+  emit the TDLib `td_api_*.cpp` auto-sources before the Android builds start,
+  stopping clang++ from failing on missing `td_api_0.cpp`.
+
 2025-11-23
 - fix(ci): Force the Standart workflow's tdutils pre-generation CMake run to
   enable `TDUTILS_MIME_TYPE`, so the `tdmime_auto` target exists and gperf can

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,10 @@
 
 Hinweis
 - Der vollständige Verlauf steht in `CHANGELOG.md`. Diese Roadmap listet nur kurzfristige und mittelfristige, umsetzbare Punkte.
+- Maintenance 2025-11-24: Standart-Workflow führt den hostseitigen
+  `prepare_cross_compiling`-Lauf wieder explizit aus, damit die TDLib
+  `td_api_*.cpp`-Autos vor dem Android-Matrix-Build entstehen und clang++
+  nicht mehr auf fehlende Dateien läuft.
 - Maintenance 2025-11-23: Standart-Workflow setzt beim tdutils MIME-Generator
   `TDUTILS_MIME_TYPE=ON`, damit die gperf-Targets (`tdmime_auto`) auf dem Host
   entstehen und der Android-Matrix-Lauf wieder startet.


### PR DESCRIPTION
## Summary
- run the Standart workflow's host-side `prepare_cross_compiling` target (with fallbacks) so TDLib's `td_api_*.cpp` auto-sources exist before the Android matrix builds
- refresh the changelog and roadmap to reflect the workflow maintenance

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133686d34883228625fe38ef3a59d7)