### PR TITLE
Add catalog sync bootstrap trigger in app shell

### DIFF
--- a/app-v2/src/main/java/com/fishit/player/v2/MainActivity.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/MainActivity.kt
@@ -8,13 +8,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.fishit.player.core.catalogsync.CatalogSyncService
 import com.fishit.player.internal.source.PlaybackSourceResolver
 import com.fishit.player.nextlib.NextlibCodecConfigurator
 import com.fishit.player.playback.domain.KidsPlaybackGate
 import com.fishit.player.playback.domain.ResumeManager
-import com.fishit.player.infra.transport.telegram.TelegramAuthClient
-import com.fishit.player.infra.transport.xtream.XtreamApiClient
 import com.fishit.player.v2.navigation.AppNavHost
 import com.fishit.player.v2.ui.theme.FishItV2Theme
 import dagger.hilt.android.AndroidEntryPoint
@@ -39,13 +36,7 @@ class MainActivity : ComponentActivity() {
     lateinit var codecConfigurator: NextlibCodecConfigurator
 
     @Inject
-    lateinit var catalogSyncService: CatalogSyncService
-
-    @Inject
-    lateinit var telegramAuthClient: TelegramAuthClient
-
-    @Inject
-    lateinit var xtreamApiClient: XtreamApiClient
+    lateinit var catalogSyncBootstrap: CatalogSyncBootstrap
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,11 +53,7 @@ class MainActivity : ComponentActivity() {
                         kidsPlaybackGate = kidsPlaybackGate,
                         sourceResolver = sourceResolver,
                         codecConfigurator = codecConfigurator,
-                        catalogSyncBootstrap = CatalogSyncBootstrap(
-                            catalogSyncService = catalogSyncService,
-                            telegramAuthClient = telegramAuthClient,
-                            xtreamApiClient = xtreamApiClient
-                        )
+                        catalogSyncBootstrap = catalogSyncBootstrap,
                     )
                 }
             }

--- a/app-v2/src/main/java/com/fishit/player/v2/di/AppScopeModule.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/di/AppScopeModule.kt
@@ -1,0 +1,25 @@
+package com.fishit.player.v2.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppScopeModule {
+
+    const val APP_LIFECYCLE_SCOPE = "AppLifecycleScope"
+
+    @Provides
+    @Singleton
+    @Named(APP_LIFECYCLE_SCOPE)
+    fun provideAppLifecycleScope(): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    }
+}

--- a/app-v2/src/main/java/com/fishit/player/v2/navigation/AppNavHost.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/navigation/AppNavHost.kt
@@ -2,7 +2,6 @@ package com.fishit.player.v2.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -41,13 +40,12 @@ fun AppNavHost(
     catalogSyncBootstrap: CatalogSyncBootstrap,
 ) {
     val navController = rememberNavController()
-    val coroutineScope = rememberCoroutineScope()
 
     FishTheme {
         LaunchedEffect(navController, catalogSyncBootstrap) {
             navController.currentBackStackEntryFlow.collectLatest { backStackEntry ->
                 if (backStackEntry.destination.route == Routes.HOME) {
-                    catalogSyncBootstrap.start(coroutineScope)
+                    catalogSyncBootstrap.start()
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a CatalogSyncBootstrap that watches Telegram and Xtream auth signals and triggers CatalogSyncService once per session
- start the bootstrap from AppNavHost when navigation reaches Home after onboarding

## Trigger location
- **AppNavHost.kt**: LaunchedEffect listens to the NavHost back stack and starts the bootstrap the first time the Home route is reached. This is the earliest post-onboarding point inside the app shell (outside Home feature UI) that runs once per session.

## Testing
- Not run (not requested)

## Manual verification
1. Install app fresh
2. Complete Telegram auth **or** Xtream connect
3. Continue to Home
4. Observe logs: "Catalog sync bootstrap triggered; telegram=<...> xtream=<...>"
5. Navigate away and back to Home → no repeated trigger


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c739058288322acf9d51a23f853ab)