### PR TITLE
Home: use repository data instead of demo rows

### DIFF
--- a/feature/home/src/main/java/com/fishit/player/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/fishit/player/feature/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.fishit.player.core.model.SourceType
 import com.fishit.player.infra.data.telegram.TelegramContentRepository
 import com.fishit.player.infra.data.xtream.XtreamCatalogRepository
 import com.fishit.player.infra.data.xtream.XtreamLiveRepository
+import com.fishit.player.infra.logging.UnifiedLog
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -123,6 +124,8 @@ class HomeViewModel @Inject constructor(
 
     fun refresh() {
         viewModelScope.launch {
+            // Clears UI error state only.
+            // Data reload is handled by background CatalogSync, not by Home.
             errorState.emit(null)
         }
     }
@@ -141,6 +144,7 @@ class HomeViewModel @Inject constructor(
         .distinctUntilChanged()
         .onStart { emit(emptyList()) }
         .catch { throwable ->
+            UnifiedLog.e(TAG, throwable) { "Error loading home content" }
             errorState.emit(throwable.message ?: "Unknown error loading content")
             emit(emptyList())
         }
@@ -163,6 +167,7 @@ class HomeViewModel @Inject constructor(
     }
 
     private companion object {
+        const val TAG = "HomeViewModel"
         const val HOME_ROW_LIMIT = 20
     }
 }


### PR DESCRIPTION
## Summary
- Wire `HomeViewModel` to Telegram, Xtream catalog, and Xtream live repositories with a shared HomeState flow.
- Replace demo item generation with RawMediaMetadata → HomeMediaItem mapping and limit each row to 20 entries.
- Preserve loading/error handling while keeping refresh as an error reset without triggering sync.

## File Paths
- feature/home/src/main/java/com/fishit/player/feature/home/HomeViewModel.kt

## Row Sources
- TelegramRecent: `TelegramContentRepository.observeAll()`
- XtreamLive: `XtreamLiveRepository.observeChannels()`
- XtreamVod: `XtreamCatalogRepository.observeVod()`
- XtreamSeries: `XtreamCatalogRepository.observeSeries()`

## Mapping Notes
- `id`/navigation use `sourceId`; title prefers `originalTitle` then `sourceLabel`; poster/backdrop fall back to `thumbnail`; duration derived from `durationMinutes`.

## Refresh Behavior
- Clears error state only; does not trigger sync or new fetch.

## Manual Checklist
- [ ] Run app
- [ ] Complete Telegram auth and/or Xtream connect
- [ ] Continue to Home
- [ ] Confirm Home shows real items (not Picsum demo)
- [ ] Confirm lists are limited (not massive)
- [ ] Confirm no sync is started from Home (logs show sync started earlier by bootstrap only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c83ef862883229ba162548916d594)