### PR TITLE
Add Xtream tap-to-play navigation from Home

### DIFF
--- a/app-v2/src/main/java/com/fishit/player/v2/navigation/AppNavHost.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/navigation/AppNavHost.kt
@@ -1,12 +1,22 @@
 package com.fishit.player.v2.navigation
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.fishit.player.core.model.MediaType
 import com.fishit.player.core.model.SourceType
 import com.fishit.player.core.ui.theme.FishTheme
 import com.fishit.player.feature.detail.UnifiedDetailEvent
@@ -16,11 +26,13 @@ import com.fishit.player.feature.home.debug.DebugPlaybackScreen
 import com.fishit.player.feature.onboarding.StartScreen
 import com.fishit.player.feature.settings.DebugScreen
 import com.fishit.player.internal.source.PlaybackSourceResolver
+import com.fishit.player.internal.ui.InternalPlayerEntry
 import com.fishit.player.nextlib.NextlibCodecConfigurator
 import com.fishit.player.playback.domain.KidsPlaybackGate
 import com.fishit.player.playback.domain.ResumeManager
 import com.fishit.player.v2.CatalogSyncBootstrap
 import com.fishit.player.v2.ui.debug.DebugSkeletonScreen
+import com.fishit.player.v2.navigation.PlayerNavViewModel
 import kotlinx.coroutines.flow.collectLatest
 
 /**
@@ -69,12 +81,23 @@ fun AppNavHost(
             composable(Routes.HOME) {
                 HomeScreen(
                     onItemClick = { item ->
-                        navController.navigate(
-                            Routes.detail(
-                                mediaId = item.navigationId,
-                                sourceType = item.navigationSource.name
+                        if (item.sourceType == SourceType.XTREAM &&
+                            (item.mediaType == MediaType.LIVE || item.mediaType == MediaType.MOVIE)
+                        ) {
+                            navController.navigate(
+                                Routes.player(
+                                    mediaId = item.navigationId,
+                                    sourceType = item.navigationSource.name
+                                )
                             )
-                        )
+                        } else {
+                            navController.navigate(
+                                Routes.detail(
+                                    mediaId = item.navigationId,
+                                    sourceType = item.navigationSource.name
+                                )
+                            )
+                        }
                     },
                     onSettingsClick = {
                         // TODO: Navigate to Settings
@@ -112,6 +135,32 @@ fun AppNavHost(
                 )
             }
 
+            composable(
+                route = Routes.PLAYER_PATTERN,
+                arguments = listOf(
+                    navArgument(Routes.ARG_MEDIA_ID) { type = NavType.StringType },
+                    navArgument(Routes.ARG_SOURCE_TYPE) { type = NavType.StringType }
+                )
+            ) { backStackEntry ->
+                val mediaId = backStackEntry.arguments?.getString(Routes.ARG_MEDIA_ID) ?: return@composable
+                val sourceTypeName = backStackEntry.arguments?.getString(Routes.ARG_SOURCE_TYPE) ?: return@composable
+                val sourceType = try {
+                    SourceType.valueOf(sourceTypeName)
+                } catch (e: Exception) {
+                    SourceType.UNKNOWN
+                }
+
+                PlayerNavScreen(
+                    mediaId = mediaId,
+                    sourceType = sourceType,
+                    resumeManager = resumeManager,
+                    kidsPlaybackGate = kidsPlaybackGate,
+                    sourceResolver = sourceResolver,
+                    codecConfigurator = codecConfigurator,
+                    onBack = { navController.popBackStack() }
+                )
+            }
+
             // Debug Screen (settings/diagnostics)
             composable(Routes.DEBUG) {
                 DebugScreen(
@@ -139,6 +188,50 @@ fun AppNavHost(
     }
 }
 
+@Composable
+private fun PlayerNavScreen(
+    mediaId: String,
+    sourceType: SourceType,
+    resumeManager: ResumeManager,
+    kidsPlaybackGate: KidsPlaybackGate,
+    sourceResolver: PlaybackSourceResolver,
+    codecConfigurator: NextlibCodecConfigurator,
+    onBack: () -> Unit,
+    viewModel: PlayerNavViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(mediaId, sourceType) {
+        viewModel.load(mediaId, sourceType)
+    }
+
+    when {
+        state.context != null -> InternalPlayerEntry(
+            playbackContext = state.context,
+            sourceResolver = sourceResolver,
+            resumeManager = resumeManager,
+            kidsPlaybackGate = kidsPlaybackGate,
+            codecConfigurator = codecConfigurator,
+            onBack = onBack
+        )
+
+        state.error != null -> {
+            LaunchedEffect(state.error) {
+                onBack()
+            }
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(text = state.error ?: "Unable to start playback")
+            }
+        }
+
+        else -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}
+
 /**
  * Route constants for navigation.
  */
@@ -154,9 +247,14 @@ object Routes {
     const val ARG_MEDIA_ID = "mediaId"
     const val ARG_SOURCE_TYPE = "sourceType"
     const val DETAIL_PATTERN = "detail/{$ARG_MEDIA_ID}/{$ARG_SOURCE_TYPE}"
+    const val PLAYER_PATTERN = "player/{$ARG_MEDIA_ID}/{$ARG_SOURCE_TYPE}"
 
     fun detail(mediaId: String, sourceType: String): String {
         return "detail/$mediaId/$sourceType"
+    }
+
+    fun player(mediaId: String, sourceType: String): String {
+        return "player/$mediaId/$sourceType"
     }
 
     // Future routes

--- a/app-v2/src/main/java/com/fishit/player/v2/navigation/PlayerNavViewModel.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/navigation/PlayerNavViewModel.kt
@@ -1,0 +1,136 @@
+package com.fishit.player.v2.navigation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fishit.player.core.model.MediaType
+import com.fishit.player.core.model.SourceType
+import com.fishit.player.core.model.extensions.MediaSourceRefExtensions.parseXtreamVodId
+import com.fishit.player.core.playermodel.PlaybackContext
+import com.fishit.player.infra.data.xtream.XtreamCatalogRepository
+import com.fishit.player.infra.data.xtream.XtreamLiveRepository
+import com.fishit.player.infra.logging.UnifiedLog
+import com.fishit.player.infra.transport.xtream.XtreamApiClient
+import com.fishit.player.playback.xtream.XtreamPlaybackSourceFactoryImpl
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.net.URI
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class PlayerNavViewModel @Inject constructor(
+    private val xtreamCatalogRepository: XtreamCatalogRepository,
+    private val xtreamLiveRepository: XtreamLiveRepository,
+    private val xtreamApiClient: XtreamApiClient,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(PlayerNavState())
+    val state: StateFlow<PlayerNavState> = _state
+
+    fun load(sourceId: String, sourceType: SourceType) {
+        viewModelScope.launch {
+            when (sourceType) {
+                SourceType.XTREAM -> loadXtreamContext(sourceId)
+                else -> _state.value = PlayerNavState(error = "Unsupported source: $sourceType")
+            }
+        }
+    }
+
+    private suspend fun loadXtreamContext(sourceId: String) {
+        val raw = when {
+            sourceId.startsWith("xtream:live:") -> xtreamLiveRepository.getBySourceId(sourceId)
+            else -> xtreamCatalogRepository.getBySourceId(sourceId)
+        }
+
+        if (raw == null) {
+            UnifiedLog.w(TAG) { "No media found for $sourceId" }
+            _state.value = PlayerNavState(error = "Item unavailable")
+            return
+        }
+
+        val context = when (raw.mediaType) {
+            MediaType.LIVE -> buildLiveContext(sourceId, raw.originalTitle)
+            MediaType.MOVIE -> buildVodContext(sourceId, raw.originalTitle)
+            else -> null
+        }
+
+        if (context == null) {
+            _state.value = PlayerNavState(error = "Playback not supported")
+        } else {
+            _state.value = PlayerNavState(context = context)
+        }
+    }
+
+    private fun buildLiveContext(sourceId: String, title: String): PlaybackContext? {
+        val streamId = sourceId.removePrefix("xtream:live:").toIntOrNull() ?: return null
+        return runCatching {
+            val uri = xtreamApiClient.buildLiveUrl(streamId)
+            PlaybackContext(
+                canonicalId = "xtream:live:$streamId",
+                sourceType = SourceType.XTREAM,
+                uri = uri,
+                title = title,
+                isLive = true,
+                isSeekable = false,
+                extras = buildXtreamExtras(
+                    contentType = XtreamPlaybackSourceFactoryImpl.CONTENT_TYPE_LIVE,
+                    streamId = streamId.toString(),
+                )
+            )
+        }.getOrElse { error ->
+            UnifiedLog.w(TAG, error) { "Failed to build live context for $sourceId" }
+            null
+        }
+    }
+
+    private fun buildVodContext(sourceId: String, title: String): PlaybackContext? {
+        val vodId = parseXtreamVodId(sourceId) ?: return null
+        return runCatching {
+            val uri = xtreamApiClient.buildVodUrl(vodId, null)
+            PlaybackContext(
+                canonicalId = "xtream:vod:$vodId",
+                sourceType = SourceType.XTREAM,
+                uri = uri,
+                title = title,
+                extras = buildXtreamExtras(
+                    contentType = XtreamPlaybackSourceFactoryImpl.CONTENT_TYPE_VOD,
+                    vodId = vodId.toString(),
+                )
+            )
+        }.getOrElse { error ->
+            UnifiedLog.w(TAG, error) { "Failed to build VOD context for $sourceId" }
+            null
+        }
+    }
+
+    private fun buildXtreamExtras(
+        contentType: String,
+        streamId: String? = null,
+        vodId: String? = null,
+    ): Map<String, String> {
+        val extras = mutableMapOf<String, String>()
+        extras[XtreamPlaybackSourceFactoryImpl.EXTRA_CONTENT_TYPE] = contentType
+        streamId?.let { extras[XtreamPlaybackSourceFactoryImpl.EXTRA_STREAM_ID] = it }
+        vodId?.let { extras[XtreamPlaybackSourceFactoryImpl.EXTRA_VOD_ID] = it }
+
+        xtreamApiClient.capabilities?.let { caps ->
+            val uri = runCatching { URI(caps.baseUrl) }.getOrNull()
+            uri?.host?.let { extras[XtreamPlaybackSourceFactoryImpl.EXTRA_SERVER_HOST] = it }
+            uri?.port?.takeIf { it > 0 }?.let { extras[XtreamPlaybackSourceFactoryImpl.EXTRA_SERVER_PORT] = it.toString() }
+            uri?.scheme?.let { extras[XtreamPlaybackSourceFactoryImpl.EXTRA_SERVER_SCHEME] = it }
+            extras[XtreamPlaybackSourceFactoryImpl.EXTRA_USERNAME] = caps.username
+        }
+
+        return extras
+    }
+
+    private companion object {
+        const val TAG = "PlayerNavViewModel"
+    }
+}
+
+data class PlayerNavState(
+    val context: PlaybackContext? = null,
+    val error: String? = null,
+)


### PR DESCRIPTION
## Summary
- add a dedicated player navigation route and PlayerNavViewModel to construct playback contexts for Xtream live and VOD items
- wire Home taps on Xtream live/VOD tiles directly to the player while leaving Telegram and Xtream series paths unchanged
- surface loading/error handling when playback context resolution fails and reuse InternalPlayerEntry for real playback

## Inventory
- Player entry: AppNavHost now includes a player route that hosts InternalPlayerEntry alongside the existing DebugPlaybackScreen route
- PlaybackContext helpers: core/player-model PlaybackContext with Xtream extras consumed by XtreamPlaybackSourceFactoryImpl (contentType/IDs/server fields)
- Xtream creds/config source: XtreamApiClient singleton retains onboarded credentials; playback URLs are built via its builders and capabilities (baseUrl/username) without new storage
- Home model: HomeMediaItem provides navigationId, navigationSource, sourceType, and mediaType for routing decisions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d429904548322a4b41591bb94df27)