### PR TITLE
RAW_METADATA_FREEZE_01: remove pipeline globalId computation

### DIFF
--- a/core/model/src/main/java/com/fishit/player/core/model/RawMediaMetadata.kt
+++ b/core/model/src/main/java/com/fishit/player/core/model/RawMediaMetadata.kt
@@ -47,9 +47,9 @@ data class RawMediaMetadata(
         /** Pipeline that produced this metadata */
         val pipelineIdTag: PipelineIdTag = PipelineIdTag.UNKNOWN,
         /**
-         * Canonical global ID for cross-pipeline deduplication. Generated via
-         * [GlobalIdUtil.generateCanonicalId] based on normalized title + year. Format:
-         * "cm:<16-char-hex>"
+         * Canonical identity key for cross-pipeline deduplication.
+         * IMPORTANT: Pipelines MUST leave this empty (""). It is assigned centrally by :core:metadata-normalizer during
+         * unification.
          */
         val globalId: String = "",
         // === Imaging Fields (v2) ===

--- a/docs/v2/MEDIA_NORMALIZATION_CONTRACT.md
+++ b/docs/v2/MEDIA_NORMALIZATION_CONTRACT.md
@@ -1,0 +1,35 @@
+# MEDIA_NORMALIZATION_CONTRACT (v2)
+
+Authoritative rules for raw pipeline outputs and centralized normalization.
+
+## RawMediaMetadata definition
+
+```
+data class RawMediaMetadata(
+    val originalTitle: String,
+    val mediaType: MediaType = MediaType.UNKNOWN,
+    val year: Int? = null,
+    val season: Int? = null,
+    val episode: Int? = null,
+    val durationMinutes: Int? = null,
+    val externalIds: ExternalIds = ExternalIds(),
+    val sourceType: SourceType,
+    val sourceLabel: String,
+    val sourceId: String,
+    val pipelineIdTag: PipelineIdTag = PipelineIdTag.UNKNOWN,
+    val globalId: String = ""  // MUST remain empty in pipelines; assigned centrally
+)
+```
+
+### Pipeline responsibilities (raw-only)
+- Provide unmodified titles and IDs from the upstream source (no cleaning, no heuristics).
+- Do not attempt TMDB/IMDB lookups or canonical identity generation.
+- Leave `globalId` empty; it is assigned by `:core:metadata-normalizer` during unification.
+
+### Normalizer responsibilities
+- Normalize titles, resolve TMDB IDs, and compute canonical identity.
+- Assign `globalId` as the single source of truth for deduplication across pipelines.
+
+## Violations
+- Pipeline sets `RawMediaMetadata.globalId` or calls any canonical-id generator (`GlobalIdUtil/generateCanonicalId`).
+- Pipeline performs title normalization, TMDB lookups, or cross-pipeline matching.

--- a/pipeline/telegram/src/main/java/com/fishit/player/pipeline/telegram/model/TelegramRawMetadataExtensions.kt
+++ b/pipeline/telegram/src/main/java/com/fishit/player/pipeline/telegram/model/TelegramRawMetadataExtensions.kt
@@ -1,7 +1,6 @@
 package com.fishit.player.pipeline.telegram.model
 
 import com.fishit.player.core.model.ExternalIds
-import com.fishit.player.core.model.GlobalIdUtil
 import com.fishit.player.core.model.MediaType
 import com.fishit.player.core.model.PipelineIdTag
 import com.fishit.player.core.model.RawMediaMetadata
@@ -52,7 +51,6 @@ fun TelegramMediaItem.toRawMediaMetadata(): RawMediaMetadata {
                 sourceId = remoteId ?: "msg:$chatId:$messageId",
                 // === Pipeline Identity (v2) ===
                 pipelineIdTag = PipelineIdTag.TELEGRAM,
-                globalId = GlobalIdUtil.generateCanonicalId(rawTitle, rawYear),
                 // === ImageRef from TelegramImageRefExtensions ===
                 poster = toPosterImageRef(), // Photo or null for video
                 backdrop = null, // Telegram doesn't provide backdrops

--- a/pipeline/telegram/src/test/java/com/fishit/player/pipeline/telegram/model/TelegramRawMetadataExtensionsTest.kt
+++ b/pipeline/telegram/src/test/java/com/fishit/player/pipeline/telegram/model/TelegramRawMetadataExtensionsTest.kt
@@ -16,11 +16,12 @@ class TelegramRawMetadataExtensionsTest {
 
     @Test
     fun `toRawMediaMetadata uses title as first priority`() {
+        val expectedRawTitle = "The Movie Title"
         val item = TelegramMediaItem(
             chatId = 123L,
             messageId = 456L,
             mediaType = TelegramMediaType.VIDEO,
-            title = "The Movie Title",
+            title = expectedRawTitle,
             episodeTitle = "Episode Name",
             caption = "Some caption",
             fileName = "movie.mkv"
@@ -28,7 +29,8 @@ class TelegramRawMetadataExtensionsTest {
 
         val raw = item.toRawMediaMetadata()
 
-        assertEquals("The Movie Title", raw.originalTitle)
+        assertEquals(expectedRawTitle, raw.originalTitle)
+        assertEquals("", raw.globalId)
     }
 
     @Test

--- a/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/mapper/XtreamRawMetadataExtensions.kt
+++ b/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/mapper/XtreamRawMetadataExtensions.kt
@@ -1,7 +1,6 @@
 package com.fishit.player.pipeline.xtream.mapper
 
 import com.fishit.player.core.model.ExternalIds
-import com.fishit.player.core.model.GlobalIdUtil
 import com.fishit.player.core.model.MediaType
 import com.fishit.player.core.model.PipelineIdTag
 import com.fishit.player.core.model.RawMediaMetadata
@@ -40,7 +39,6 @@ fun XtreamVodItem.toRawMediaMetadata(
 ): RawMediaMetadata {
         val rawTitle = name
         val rawYear: Int? = null // Xtream VOD list doesn't include year; detail fetch required
-        val canonicalId = canonicalIdWithFallback(rawTitle, rawYear, "xc:vod:$id")
         return RawMediaMetadata(
                 originalTitle = rawTitle,
                 mediaType = MediaType.MOVIE,
@@ -55,7 +53,6 @@ fun XtreamVodItem.toRawMediaMetadata(
                 sourceId = "xtream:vod:$id",
                 // === Pipeline Identity (v2) ===
                 pipelineIdTag = PipelineIdTag.XTREAM,
-                globalId = canonicalId,
                 // === ImageRef from XtreamImageRefExtensions ===
                 poster = toPosterImageRef(authHeaders),
                 backdrop = null, // VOD list doesn't provide backdrop
@@ -77,7 +74,6 @@ fun XtreamSeriesItem.toRawMediaMetadata(
 ): RawMediaMetadata {
         val rawTitle = name
         val rawYear = year?.toIntOrNull()
-        val canonicalId = canonicalIdWithFallback(rawTitle, rawYear, "xc:series:$id")
         return RawMediaMetadata(
                 originalTitle = rawTitle,
                 mediaType = MediaType.SERIES, // Series container, not episode
@@ -91,7 +87,6 @@ fun XtreamSeriesItem.toRawMediaMetadata(
                 sourceId = "xtream:series:$id",
                 // === Pipeline Identity (v2) ===
                 pipelineIdTag = PipelineIdTag.XTREAM,
-                globalId = canonicalId,
                 // === ImageRef from XtreamImageRefExtensions ===
                 poster = toPosterImageRef(authHeaders),
                 backdrop = null, // Series list doesn't provide backdrop
@@ -117,7 +112,6 @@ fun XtreamEpisode.toRawMediaMetadata(
         val effectiveSeriesName = seriesName ?: seriesNameOverride
         val rawTitle = title.ifBlank { effectiveSeriesName ?: "Episode $episodeNumber" }
         val rawYear: Int? = null // Episodes typically don't have year; inherit from series
-        val canonicalId = canonicalIdWithFallback(rawTitle, rawYear, "xc:episode:$id")
         return RawMediaMetadata(
                 originalTitle = rawTitle,
                 mediaType = MediaType.SERIES_EPISODE,
@@ -131,7 +125,6 @@ fun XtreamEpisode.toRawMediaMetadata(
                 sourceId = "xtream:episode:$id",
                 // === Pipeline Identity (v2) ===
                 pipelineIdTag = PipelineIdTag.XTREAM,
-                globalId = canonicalId,
                 // === ImageRef from XtreamImageRefExtensions ===
                 poster = null, // Episodes don't have poster; inherit from series
                 backdrop = null,
@@ -149,7 +142,6 @@ fun XtreamChannel.toRawMediaMetadata(
         authHeaders: Map<String, String> = emptyMap(),
 ): RawMediaMetadata {
         val rawTitle = name
-        val canonicalId = canonicalIdWithFallback(rawTitle, null, "xc:live:$id")
         return RawMediaMetadata(
                 originalTitle = rawTitle,
                 mediaType = MediaType.LIVE,
@@ -163,19 +155,9 @@ fun XtreamChannel.toRawMediaMetadata(
                 sourceId = "xtream:live:$id",
                 // === Pipeline Identity (v2) ===
                 pipelineIdTag = PipelineIdTag.XTREAM,
-                globalId = canonicalId,
                 // === ImageRef from XtreamImageRefExtensions ===
                 poster = toLogoImageRef(authHeaders), // Use logo as poster for channels
                 backdrop = null,
                 thumbnail = toLogoImageRef(authHeaders), // Thumbnail same as logo
         )
-}
-
-private fun canonicalIdWithFallback(title: String, year: Int?, disambiguator: String): String {
-        return if (year != null) {
-                GlobalIdUtil.generateCanonicalId(title, year)
-        } else {
-                // Use a disambiguator to avoid merging unrelated titles when year is missing
-                GlobalIdUtil.generateCanonicalId("$title|$disambiguator", year)
-        }
 }

--- a/pipeline/xtream/src/test/java/com/fishit/player/pipeline/xtream/model/XtreamRawMetadataExtensionsTest.kt
+++ b/pipeline/xtream/src/test/java/com/fishit/player/pipeline/xtream/model/XtreamRawMetadataExtensionsTest.kt
@@ -31,6 +31,7 @@ class XtreamRawMetadataExtensionsTest {
         assertEquals(SourceType.XTREAM, raw.sourceType)
         assertEquals("xtream:vod:123", raw.sourceId)
         assertEquals("Xtream VOD", raw.sourceLabel)
+        assertEquals("", raw.globalId)
         assertNull(raw.year) // Not available in list
         assertNull(raw.season)
         assertNull(raw.episode)
@@ -53,6 +54,7 @@ class XtreamRawMetadataExtensionsTest {
         assertEquals(SourceType.XTREAM, raw.sourceType)
         assertEquals("xtream:series:456", raw.sourceId)
         assertEquals("Xtream Series", raw.sourceLabel)
+        assertEquals("", raw.globalId)
     }
 
     @Test
@@ -75,6 +77,7 @@ class XtreamRawMetadataExtensionsTest {
         assertEquals("Xtream: Breaking Bad", raw.sourceLabel)
         assertEquals(1, raw.season)
         assertEquals(5, raw.episode)
+        assertEquals("", raw.globalId)
     }
 
     @Test
@@ -91,6 +94,7 @@ class XtreamRawMetadataExtensionsTest {
         val raw = episode.toRawMediaMetadata(seriesName = "Breaking Bad")
 
         assertEquals("Breaking Bad", raw.originalTitle) // Falls back to series name
+        assertEquals("", raw.globalId)
     }
 
     @Test
@@ -111,6 +115,7 @@ class XtreamRawMetadataExtensionsTest {
         assertEquals(SourceType.XTREAM, raw.sourceType)
         assertEquals("xtream:live:101", raw.sourceId)
         assertEquals("Xtream Live", raw.sourceLabel)
+        assertEquals("", raw.globalId)
     }
 
     @Test

--- a/scripts/ci/check-arch-guardrails.sh
+++ b/scripts/ci/check-arch-guardrails.sh
@@ -304,7 +304,7 @@ if [[ -n "$violations" ]]; then
     VIOLATIONS=$((VIOLATIONS + 1))
 fi
 
-violations=$(grep -R -n -E '^[^/]*(\s)*globalId\s*=' pipeline/ --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy 2>/dev/null || true)
+violations=$(grep -R -n -E 'globalId\s*=' pipeline/ --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy 2>/dev/null || true)
 if [[ -n "$violations" ]]; then
     echo "$violations"
     echo "❌ VIOLATION: Pipeline assigns RawMediaMetadata.globalId (must remain empty)"

--- a/scripts/ci/check-arch-guardrails.sh
+++ b/scripts/ci/check-arch-guardrails.sh
@@ -286,6 +286,32 @@ if [[ -n "$violations" ]]; then
 fi
 
 # ======================================================================
+# RAW_METADATA_GLOBALID_GUARD: Pipelines must not set/compute globalId
+# ======================================================================
+echo "Running RAW_METADATA_GLOBALID_GUARD..."
+
+violations=$(grep -R -n "GlobalIdUtil" pipeline/ --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy 2>/dev/null || true)
+if [[ -n "$violations" ]]; then
+    echo "$violations"
+    echo "❌ VIOLATION: Pipeline references GlobalIdUtil (globalId is assigned centrally)"
+    VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
+violations=$(grep -R -n "generateCanonicalId(" pipeline/ --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy 2>/dev/null || true)
+if [[ -n "$violations" ]]; then
+    echo "$violations"
+    echo "❌ VIOLATION: Pipeline attempts canonical-id generation (forbidden)"
+    VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
+violations=$(grep -R -n -E '^[^/]*(\s)*globalId\s*=' pipeline/ --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy 2>/dev/null || true)
+if [[ -n "$violations" ]]; then
+    echo "$violations"
+    echo "❌ VIOLATION: Pipeline assigns RawMediaMetadata.globalId (must remain empty)"
+    VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
+# ======================================================================
 # APP-V2 LAYER: Check for forbidden imports (Phase A1.2)
 # ======================================================================
 echo "Checking app-v2 layer for forbidden imports..."


### PR DESCRIPTION
## Summary
- update RawMediaMetadata contract and docs to require pipelines leave globalId empty and document the rule
- strip GlobalIdUtil usage and globalId assignments from Telegram and Xtream pipelines and harden unit tests
- add CI guardrail to block pipeline globalId generation and add normalization contract doc entry

## Testing
- bash scripts/ci/check-arch-guardrails.sh *(fails: existing Telegram auth guardrail violation unrelated to this change)*
- ./gradlew :pipeline:telegram:testDebugUnitTest :pipeline:xtream:testDebugUnitTest --no-build-cache --console=plain *(fails: Android SDK not configured in environment)*
- ./gradlew :pipeline:telegram:compileReleaseKotlin :pipeline:xtream:compileReleaseKotlin :app-v2:compileReleaseKotlin --no-build-cache --console=plain *(fails: Android SDK not configured in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694033befe1883229ad4dc4440e997b3)