### PR TITLE
Move GlobalIdUtil to metadata normalizer and enforce ownership guard

### DIFF
--- a/core/metadata-normalizer/src/main/java/com/fishit/player/core/metadata/GlobalIdUtil.kt
+++ b/core/metadata-normalizer/src/main/java/com/fishit/player/core/metadata/GlobalIdUtil.kt
@@ -1,4 +1,4 @@
-package com.fishit.player.core.model
+package com.fishit.player.core.metadata
 
 import java.security.MessageDigest
 
@@ -24,7 +24,7 @@ object GlobalIdUtil {
     // Basic scene tags to strip (resolution, codec, group, source)
     private val sceneTagPattern =
             Regex(
-                    """[.\s]*(720p|1080p|2160p|4k|uhd|hdr|bluray|bdrip|webrip|web-dl|hdtv|dvdrip|x264|x265|h264|h265|aac|dts|ac3|atmos|remux|\[.*?]|-.{1,15}$)""",
+                    """[\.\s]*(720p|1080p|2160p|4k|uhd|hdr|bluray|bdrip|webrip|web-dl|hdtv|dvdrip|x264|x265|h264|h265|aac|dts|ac3|atmos|remux|\[.*?]|-.{1,15}$)""",
                     RegexOption.IGNORE_CASE,
             )
 

--- a/core/metadata-normalizer/src/main/java/com/fishit/player/core/metadata/Normalizer.kt
+++ b/core/metadata-normalizer/src/main/java/com/fishit/player/core/metadata/Normalizer.kt
@@ -1,6 +1,5 @@
 package com.fishit.player.core.metadata
 
-import com.fishit.player.core.model.GlobalIdUtil
 import com.fishit.player.core.model.MediaVariant
 import com.fishit.player.core.model.NormalizedMedia
 import com.fishit.player.core.model.QualityTags

--- a/scripts/ci/check-arch-guardrails.sh
+++ b/scripts/ci/check-arch-guardrails.sh
@@ -208,6 +208,20 @@ filter_allowlisted() {
 load_allowlist
 
 # ======================================================================
+# GLOBAL_ID_UTIL_OWNERSHIP_GUARD: Restrict GlobalIdUtil to metadata-normalizer
+# ======================================================================
+echo "Running GLOBAL_ID_UTIL_OWNERSHIP_GUARD..."
+
+globalid_hits=$(grep -R -n "GlobalIdUtil" . --include="*.kt" --exclude-dir=build --exclude-dir=generated --exclude-dir=legacy --exclude-dir=.gradle --exclude-dir=.git || true)
+violations=$(echo "$globalid_hits" | grep -vE "^(\./)?core/metadata-normalizer/" || true)
+
+if [[ -n "$violations" ]]; then
+    echo "$violations"
+    echo "❌ VIOLATION: GlobalIdUtil referenced outside core/metadata-normalizer (ownership restriction)."
+    VIOLATIONS=$((VIOLATIONS + 1))
+fi
+
+# ======================================================================
 # CONTRACT UNIQUENESS: MEDIA_NORMALIZATION_CONTRACT.md must be canonical
 # ======================================================================
 echo "Checking normalization contract doc uniqueness..."


### PR DESCRIPTION
## Summary
- relocate GlobalIdUtil into the metadata-normalizer module and update references
- remove the utility from core:model to keep the model layer free of normalization logic
- add a guardrail check to block GlobalIdUtil usage outside metadata-normalizer

## Testing
- bash scripts/ci/check-arch-guardrails.sh
- ./gradlew :core:metadata-normalizer:compileReleaseKotlin :core:model:compileReleaseKotlin :app-v2:compileReleaseKotlin --no-build-cache --console=plain *(fails: missing Android SDK/ANDROID_HOME)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408e606d788322a20717811c37ae81)