### PR TITLE
Add WorkManager scaffolding for catalog sync scheduling

### DIFF
--- a/app-v2/build.gradle.kts
+++ b/app-v2/build.gradle.kts
@@ -187,6 +187,11 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.56.1")
     ksp("com.google.dagger:hilt-compiler:2.56.1")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("androidx.hilt:hilt-work:1.2.0")
+    ksp("androidx.hilt:hilt-compiler:1.2.0")
+
+    // WorkManager
+    implementation("androidx.work:work-runtime-ktx:2.10.5")
 
     // Compose
     implementation(platform("androidx.compose:compose-bom:2024.12.01"))

--- a/app-v2/src/main/java/com/fishit/player/v2/FishItV2Application.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/FishItV2Application.kt
@@ -1,6 +1,7 @@
 package com.fishit.player.v2
 
 import android.app.Application
+import androidx.work.Configuration
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -28,13 +29,17 @@ import javax.inject.Provider
 @HiltAndroidApp
 class FishItV2Application :
     Application(),
-    SingletonImageLoader.Factory {
+    SingletonImageLoader.Factory,
+    Configuration.Provider {
     /**
      * Lazy provider for ImageLoader to avoid DI initialization order issues.
      * Hilt ensures this is initialized before newImageLoader() is called.
      */
     @Inject
     lateinit var imageLoaderProvider: Provider<ImageLoader>
+
+    @Inject
+    lateinit var workManagerConfiguration: Configuration
 
     override fun onCreate() {
         super.onCreate()
@@ -65,4 +70,6 @@ class FishItV2Application :
      * @return The DI-configured ImageLoader singleton
      */
     override fun newImageLoader(context: PlatformContext): ImageLoader = imageLoaderProvider.get()
+
+    override fun getWorkManagerConfiguration(): Configuration = workManagerConfiguration
 }

--- a/app-v2/src/main/java/com/fishit/player/v2/di/AppWorkModule.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/di/AppWorkModule.kt
@@ -1,0 +1,32 @@
+package com.fishit.player.v2.di
+
+import android.content.Context
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import com.fishit.player.v2.work.CatalogSyncWorkScheduler
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppWorkModule {
+
+    @Provides
+    @Singleton
+    fun provideWorkManagerConfiguration(
+        workerFactory: HiltWorkerFactory,
+    ): Configuration =
+        Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+    @Provides
+    @Singleton
+    fun provideCatalogSyncWorkScheduler(
+        @ApplicationContext context: Context,
+    ): CatalogSyncWorkScheduler = CatalogSyncWorkScheduler(context)
+}

--- a/app-v2/src/main/java/com/fishit/player/v2/work/CatalogSyncOrchestratorWorker.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/work/CatalogSyncOrchestratorWorker.kt
@@ -1,0 +1,20 @@
+package com.fishit.player.v2.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class CatalogSyncOrchestratorWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+) : CoroutineWorker(context, workerParams) {
+
+    override suspend fun doWork(): Result {
+        // TODO: Implement catalog sync orchestration once infra:work is ready
+        return Result.success()
+    }
+}

--- a/app-v2/src/main/java/com/fishit/player/v2/work/CatalogSyncWorkScheduler.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/work/CatalogSyncWorkScheduler.kt
@@ -1,0 +1,94 @@
+package com.fishit.player.v2.work
+
+import android.content.Context
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal const val WORK_NAME = "catalog_sync_global"
+private const val CATALOG_SYNC_TAG = "catalog_sync"
+private const val WORKER_TAG = "worker/CatalogSyncOrchestratorWorker"
+
+private const val KEY_SYNC_RUN_ID = "sync_run_id"
+private const val KEY_SYNC_MODE = "sync_mode"
+private const val KEY_ACTIVE_SOURCES = "active_sources"
+private const val KEY_WIFI_ONLY = "wifi_only"
+private const val KEY_MAX_RUNTIME_MS = "max_runtime_ms"
+private const val KEY_DEVICE_CLASS = "device_class"
+
+/**
+ * Schedules catalog synchronization work using WorkManager.
+ */
+@Singleton
+class CatalogSyncWorkScheduler @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    fun schedule(request: CatalogSyncWorkRequest) {
+        WorkManager
+            .getInstance(context)
+            .enqueueUniqueWork(
+                WORK_NAME,
+                request.mode.workPolicy,
+                buildRequest(request),
+            )
+    }
+
+    fun cancel() {
+        WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+    }
+
+    private fun buildRequest(request: CatalogSyncWorkRequest): OneTimeWorkRequest {
+        val inputData = Data.Builder()
+            .putString(KEY_SYNC_RUN_ID, request.syncRunId)
+            .putString(KEY_SYNC_MODE, request.mode.storageValue)
+            .putStringArray(KEY_ACTIVE_SOURCES, request.activeSources.toTypedArray())
+            .putBoolean(KEY_WIFI_ONLY, request.wifiOnly)
+            .putLong(KEY_MAX_RUNTIME_MS, request.maxRuntimeMs ?: 0L)
+            .putString(KEY_DEVICE_CLASS, request.deviceClass.orEmpty())
+            .build()
+
+        return OneTimeWorkRequestBuilder<CatalogSyncOrchestratorWorker>()
+            .setInputData(inputData)
+            .addTag(CATALOG_SYNC_TAG)
+            .addTag(request.mode.tagValue)
+            .addTag(WORKER_TAG)
+            .build()
+    }
+}
+
+data class CatalogSyncWorkRequest(
+    val syncRunId: String,
+    val mode: CatalogSyncWorkMode,
+    val activeSources: List<String> = emptyList(),
+    val wifiOnly: Boolean = false,
+    val maxRuntimeMs: Long? = null,
+    val deviceClass: String? = null,
+)
+
+enum class CatalogSyncWorkMode(
+    val storageValue: String,
+    val tagValue: String,
+    val workPolicy: ExistingWorkPolicy,
+) {
+    AUTO(
+        storageValue = "auto",
+        tagValue = "mode_auto",
+        workPolicy = ExistingWorkPolicy.KEEP,
+    ),
+    EXPERT_NOW(
+        storageValue = "expert_now",
+        tagValue = "mode_expert_now",
+        workPolicy = ExistingWorkPolicy.KEEP,
+    ),
+    FORCE_RESCAN(
+        storageValue = "force_rescan",
+        tagValue = "mode_force_rescan",
+        workPolicy = ExistingWorkPolicy.REPLACE,
+    ),
+}


### PR DESCRIPTION
## Summary
- add WorkManager dependencies to app-v2 and wire WorkManager configuration through Hilt
- scaffold catalog sync WorkManager scheduler and orchestrator worker with required tags and data payload
- provide DI bindings to expose the scheduler and WorkManager configuration provider

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69446f7b362c83229021030a11047cc7)