### PR TITLE
Use work scheduler for catalog sync bootstrap

### DIFF
--- a/app-v2/build.gradle.kts
+++ b/app-v2/build.gradle.kts
@@ -175,6 +175,7 @@ dependencies {
     implementation(project(":infra:data-telegram"))
     implementation(project(":infra:data-xtream"))
     implementation(project(":infra:data-home"))
+    implementation(project(":infra:work"))
 
     // Coil for ImageLoader singleton
     implementation("io.coil-kt.coil3:coil-compose:3.0.4")

--- a/core/catalog-sync/src/main/java/com/fishit/player/core/catalogsync/CatalogSyncWorkScheduler.kt
+++ b/core/catalog-sync/src/main/java/com/fishit/player/core/catalogsync/CatalogSyncWorkScheduler.kt
@@ -1,0 +1,19 @@
+package com.fishit.player.core.catalogsync
+
+/**
+ * Schedules catalog synchronization work (typically via WorkManager).
+ *
+ * This is triggered by app bootstraps once authentication/connectivity
+ * is ready, avoiding direct orchestration from the UI layer.
+ */
+interface CatalogSyncWorkScheduler {
+    /**
+     * Enqueue the default/automatic catalog sync policy.
+     */
+    fun enqueueAutoSync()
+
+    /**
+     * Enqueue an on-demand sync with the most aggressive settings available.
+     */
+    fun enqueueExpertSyncNow()
+}

--- a/infra/work/src/main/java/com/fishit/player/infra/work/DefaultCatalogSyncWorkScheduler.kt
+++ b/infra/work/src/main/java/com/fishit/player/infra/work/DefaultCatalogSyncWorkScheduler.kt
@@ -1,0 +1,28 @@
+package com.fishit.player.infra.work
+
+import com.fishit.player.core.catalogsync.CatalogSyncWorkScheduler
+import com.fishit.player.infra.logging.UnifiedLog
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Placeholder implementation that will route catalog sync triggers through WorkManager.
+ *
+ * Currently performs a no-op aside from logging; WorkManager integration will be
+ * wired when background sync is implemented.
+ */
+@Singleton
+class DefaultCatalogSyncWorkScheduler @Inject constructor() : CatalogSyncWorkScheduler {
+
+    override fun enqueueAutoSync() {
+        UnifiedLog.i(TAG) { "enqueueAutoSync() invoked (no-op placeholder)" }
+    }
+
+    override fun enqueueExpertSyncNow() {
+        UnifiedLog.i(TAG) { "enqueueExpertSyncNow() invoked (no-op placeholder)" }
+    }
+
+    private companion object {
+        private const val TAG = "CatalogSyncWorkScheduler"
+    }
+}

--- a/infra/work/src/main/java/com/fishit/player/infra/work/WorkSchedulerModule.kt
+++ b/infra/work/src/main/java/com/fishit/player/infra/work/WorkSchedulerModule.kt
@@ -1,8 +1,11 @@
 package com.fishit.player.infra.work
 
+import com.fishit.player.core.catalogsync.CatalogSyncWorkScheduler
+import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 /**
  * RESERVED MODULE: Work Scheduler Infrastructure
@@ -28,4 +31,15 @@ import dagger.hilt.components.SingletonComponent
 object WorkSchedulerModule {
     // TODO: Provide WorkManager configuration when ready
     // TODO: Provide scheduler API for catalog sync triggers
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CatalogSyncWorkSchedulerModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCatalogSyncWorkScheduler(
+        impl: DefaultCatalogSyncWorkScheduler
+    ): CatalogSyncWorkScheduler
 }


### PR DESCRIPTION
## Summary
- add a catalog sync work scheduler contract and placeholder implementation bound in the work module
- switch CatalogSyncBootstrap to enqueue work scheduler jobs instead of launching catalog sync service flows
- wire app-v2 to the work scheduler module dependency for DI

## Testing
- :app-v2:compileDebugKotlin *(fails: Android SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694489c3c8ac8322b8b80f8a9c34ab55)