### PR TITLE
Refactor catalog sync bootstrap to domain auth readiness

### DIFF
--- a/app-v2/src/main/java/com/fishit/player/v2/CatalogSyncBootstrap.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/CatalogSyncBootstrap.kt
@@ -1,43 +1,44 @@
 package com.fishit.player.v2
 
 import com.fishit.player.core.catalogsync.CatalogSyncWorkScheduler
+import com.fishit.player.core.feature.auth.TelegramAuthRepository
+import com.fishit.player.core.feature.auth.TelegramAuthState
+import com.fishit.player.feature.onboarding.domain.XtreamAuthRepository
+import com.fishit.player.feature.onboarding.domain.XtreamAuthState
+import com.fishit.player.feature.onboarding.domain.XtreamConnectionState
 import com.fishit.player.infra.logging.UnifiedLog
-import com.fishit.player.infra.transport.telegram.TelegramAuthClient
-import com.fishit.player.infra.transport.telegram.api.TdlibAuthState
-import com.fishit.player.infra.transport.xtream.XtreamApiClient
-import com.fishit.player.infra.transport.xtream.XtreamConnectionState
 import com.fishit.player.v2.di.AppScopeModule
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicBoolean
-import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Singleton
 
 /**
  * Bootstraps catalog synchronization once per app session after authentication succeeds.
  *
  * Responsibilities:
- * - Observe auth/connection state from Telegram and Xtream clients
+ * - Observe auth/connection state from Telegram and Xtream repositories (domain layer)
  * - Trigger catalog sync when authentication is ready
  * - Does NOT handle session initialization (that's XtreamSessionBootstrap's job)
  */
-    @Singleton
-    class CatalogSyncBootstrap
-        @Inject
-        constructor(
-            private val catalogSyncWorkScheduler: CatalogSyncWorkScheduler,
-            private val telegramAuthClient: TelegramAuthClient,
-            private val xtreamApiClient: XtreamApiClient,
-            @Named(AppScopeModule.APP_LIFECYCLE_SCOPE)
-            private val appScope: CoroutineScope,
-        ) {
+@Singleton
+class CatalogSyncBootstrap
+    @Inject
+    constructor(
+        private val catalogSyncWorkScheduler: CatalogSyncWorkScheduler,
+        private val telegramAuthRepository: TelegramAuthRepository,
+        private val xtreamAuthRepository: XtreamAuthRepository,
+        @Named(AppScopeModule.APP_LIFECYCLE_SCOPE)
+        private val appScope: CoroutineScope,
+    ) {
         private val hasStarted = AtomicBoolean(false)
         private val hasTriggered = AtomicBoolean(false)
 
@@ -51,35 +52,36 @@ import javax.inject.Singleton
 
             appScope.launch {
                 try {
-                    val (telegramReady, xtreamConnected) =
+                    val readinessSnapshot =
                         combine(
-                            telegramAuthClient.authState
-                                .map { it is TdlibAuthState.Ready }
-                                .onStart {
-                                    val isAuthorized =
-                                        runCatching { telegramAuthClient.isAuthorized() }
-                                            .onFailure { error ->
-                                                UnifiedLog.w(TAG) { "Failed to check Telegram auth: ${error.message}" }
-                                            }
-                                            .getOrDefault(false)
-                                    emit(isAuthorized)
-                                },
-                            xtreamApiClient.connectionState
-                                .map { it is XtreamConnectionState.Connected }
-                                .onStart {
-                                    emit(xtreamApiClient.connectionState.value is XtreamConnectionState.Connected)
-                                },
-                        ) { telegramAuthenticated, xtreamAuthenticated ->
-                            UnifiedLog.d(TAG) { "Auth state update: telegram=$telegramAuthenticated, xtream=$xtreamAuthenticated" }
-                            telegramAuthenticated to xtreamAuthenticated
-                        }.distinctUntilChanged()
-                            .first { (telegramAuthenticated, xtreamAuthenticated) ->
-                                val hasAuth = telegramAuthenticated || xtreamAuthenticated
-                                UnifiedLog.d(TAG) { "Checking auth state: hasAuth=$hasAuth" }
-                                hasAuth
+                            telegramAuthRepository.authState.map { state ->
+                                state.toTelegramReadiness()
+                            },
+                            combine(
+                                xtreamAuthRepository.connectionState,
+                                xtreamAuthRepository.authState,
+                            ) { connection, auth ->
+                                XtreamReadiness(connectionState = connection, authState = auth)
+                            },
+                        ) { telegramReadiness, xtreamReadiness ->
+                            val snapshot = AuthReadinessSnapshot(telegramReadiness, xtreamReadiness)
+                            UnifiedLog.d(TAG) {
+                                "Auth state update: telegram=${telegramReadiness.state} (ready=${telegramReadiness.isReady}), " +
+                                    "xtreamConn=${xtreamReadiness.connectionState} " +
+                                    "xtreamAuth=${xtreamReadiness.authState} (ready=${xtreamReadiness.isReady})"
                             }
+                            snapshot
+                        }
+                            .distinctUntilChanged()
+                            .onEach { snapshot ->
+                                UnifiedLog.d(TAG) { "Checking auth state: hasAuth=${snapshot.hasReadySource}" }
+                            }
+                            .first { snapshot -> snapshot.hasReadySource }
 
-                    triggerSync(telegramReady, xtreamConnected)
+                    triggerSync(
+                        telegramReady = readinessSnapshot.telegram.isReady,
+                        xtreamConnected = readinessSnapshot.xtream.isReady,
+                    )
                 } catch (cancellation: CancellationException) {
                     UnifiedLog.d(TAG) { "Catalog sync bootstrap cancelled" }
                     throw cancellation
@@ -98,6 +100,32 @@ import javax.inject.Singleton
             UnifiedLog.i(TAG) { "Catalog sync bootstrap triggered; telegram=$telegramReady xtream=$xtreamConnected" }
             catalogSyncWorkScheduler.enqueueAutoSync()
         }
+
+        private data class AuthReadinessSnapshot(
+            val telegram: TelegramReadiness,
+            val xtream: XtreamReadiness,
+        ) {
+            val hasReadySource: Boolean
+                get() = telegram.isReady || xtream.isReady
+        }
+
+        private data class TelegramReadiness(
+            val state: TelegramAuthState,
+            val isReady: Boolean,
+        )
+
+        private data class XtreamReadiness(
+            val connectionState: XtreamConnectionState,
+            val authState: XtreamAuthState,
+        ) {
+            val isReady: Boolean
+                get() =
+                    connectionState is XtreamConnectionState.Connected &&
+                        authState is XtreamAuthState.Authenticated
+        }
+
+        private fun TelegramAuthState.toTelegramReadiness(): TelegramReadiness =
+            TelegramReadiness(state = this, isReady = this is TelegramAuthState.Connected)
 
         private companion object {
             private const val TAG = "CatalogSyncBootstrap"

--- a/scripts/ci/arch-guardrails-allowlist.txt
+++ b/scripts/ci/arch-guardrails-allowlist.txt
@@ -32,7 +32,6 @@ app-v2/src/main/java/com/fishit/player/v2/di/TelegramAuthModule.kt # TEMP until 
 app-v2/src/main/java/com/fishit/player/v2/di/ImagingModule.kt # TEMP until 2026-06-01: Coil ImageLoader with TelegramThumbFetcher - needs infra/imaging module
 app-v2/src/main/java/com/fishit/player/v2/di/TelegramThumbFetcherImpl.kt # TEMP until 2026-06-01: Adapter for Coil Fetcher interface - move to infra/imaging
 app-v2/src/main/java/com/fishit/player/v2/XtreamSessionBootstrap.kt # TEMP until 2026-06-01: Bootstrap observing XtreamApiClient - refactor to domain event
-app-v2/src/main/java/com/fishit/player/v2/CatalogSyncBootstrap.kt # TEMP until 2026-06-01: Bootstrap observing transport state - refactor to domain event
 
 # ======================================================================
 # Growth Cap: Maximum 10 entries allowed


### PR DESCRIPTION
## Summary
- refactor CatalogSyncBootstrap to observe Telegram and Xtream domain auth repositories
- map domain auth/connection states to readiness before triggering catalog sync
- remove the temporary transport allowlist entry for CatalogSyncBootstrap

## Testing
- ./scripts/ci/check-arch-guardrails.sh (fails: feature:onboarding has forbidden dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946955f044c8322a38f59180b7e74ae)