### PR TITLE
Add debug guard for missing Telegram API credentials

### DIFF
--- a/app-v2/README.md
+++ b/app-v2/README.md
@@ -1,0 +1,20 @@
+# app-v2
+
+## Telegram API credentials
+
+The TDLib session requires Telegram API credentials to be provided at build time. The Gradle configuration reads them from the environment:
+
+- `TG_API_ID` — numeric API ID from [my.telegram.org](https://my.telegram.org/apps)
+- `TG_API_HASH` — API hash from the same Telegram app configuration
+
+### Local builds
+
+Export the variables before invoking Gradle so `BuildConfig` contains valid values:
+
+```bash
+export TG_API_ID=<api_id>
+export TG_API_HASH=<api_hash>
+./gradlew :app-v2:assembleDebug
+```
+
+If either value is missing or empty in debug builds, app startup will fail fast in `TelegramAuthModule` to surface the misconfiguration. Release builds will log a warning instead.

--- a/app-v2/src/main/java/com/fishit/player/v2/di/TelegramAuthModule.kt
+++ b/app-v2/src/main/java/com/fishit/player/v2/di/TelegramAuthModule.kt
@@ -36,7 +36,13 @@ object TelegramAuthModule {
         val filesDir = File(sessionRoot, "files").apply { mkdirs() }
 
         if (BuildConfig.TG_API_ID == 0 || BuildConfig.TG_API_HASH.isBlank()) {
-            UnifiedLog.w(TAG) { "Telegram API credentials are missing; auth will fail" }
+            val message = "Telegram API credentials are missing. Set TG_API_ID and TG_API_HASH."
+            if (BuildConfig.DEBUG) {
+                UnifiedLog.e(TAG) { message }
+                throw IllegalStateException(message)
+            } else {
+                UnifiedLog.w(TAG) { message }
+            }
         }
 
         return TelegramSessionConfig(


### PR DESCRIPTION
## Summary
- fail fast in debug builds when Telegram API credentials are missing
- log a warning in release builds while keeping existing configuration
- document required TG_API_ID and TG_API_HASH environment variables for app-v2 builds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a0328fd08322bc0ffd0c8b2535b9)