### PR TITLE
Add default Xtream headers for API, playback, and imaging

### DIFF
--- a/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/XtreamHttpHeaders.kt
+++ b/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/XtreamHttpHeaders.kt
@@ -1,0 +1,39 @@
+package com.fishit.player.infra.transport.xtream
+
+/**
+ * Shared HTTP header defaults for Xtream integrations.
+ *
+ * Legacy-compatible defaults mimic common Android Xtream players so that
+ * panels that gate requests on User-Agent or Referer continue to work when
+ * callers provide no explicit headers.
+ */
+object XtreamHttpHeaders {
+    const val LEGACY_USER_AGENT: String = "IBOPlayer/1.4 (Android)"
+
+    /**
+     * Default header set when no caller-supplied headers are available.
+     *
+     * @param referer Optional referer to include alongside the legacy user agent
+     */
+    fun defaults(referer: String? = null): Map<String, String> =
+        buildMap {
+            put("User-Agent", LEGACY_USER_AGENT)
+            referer?.takeIf { it.isNotBlank() }?.let { put("Referer", it) }
+        }
+
+    /**
+     * Merge caller-supplied headers with legacy defaults when needed.
+     *
+     * The returned map always includes the legacy User-Agent when absent and
+     * adds the provided Referer when it is not already present.
+     */
+    fun withDefaults(headers: Map<String, String> = emptyMap(), referer: String? = null): Map<String, String> {
+        val normalizedReferer = referer?.takeIf { it.isNotBlank() }
+        val merged = headers.toMutableMap()
+
+        merged.putIfAbsent("User-Agent", LEGACY_USER_AGENT)
+        normalizedReferer?.let { merged.putIfAbsent("Referer", it) }
+
+        return merged
+    }
+}

--- a/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/di/XtreamTransportModule.kt
+++ b/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/di/XtreamTransportModule.kt
@@ -5,6 +5,7 @@ import com.fishit.player.infra.transport.xtream.EncryptedXtreamCredentialsStore
 import com.fishit.player.infra.transport.xtream.XtreamApiClient
 import com.fishit.player.infra.transport.xtream.XtreamCredentialsStore
 import com.fishit.player.infra.transport.xtream.XtreamDiscovery
+import com.fishit.player.infra.transport.xtream.XtreamHttpHeaders
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -33,6 +34,16 @@ object XtreamTransportModule {
             .writeTimeout(15, TimeUnit.SECONDS)
             .followRedirects(true)
             .followSslRedirects(true)
+            .addInterceptor { chain ->
+                val request = chain.request()
+                val builder = request.newBuilder()
+
+                if (request.header("User-Agent") == null) {
+                    builder.header("User-Agent", XtreamHttpHeaders.LEGACY_USER_AGENT)
+                }
+
+                chain.proceed(builder.build())
+            }
             .build()
 
     @Provides

--- a/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/catalog/XtreamCatalogPipelineImpl.kt
+++ b/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/catalog/XtreamCatalogPipelineImpl.kt
@@ -1,6 +1,7 @@
 package com.fishit.player.pipeline.xtream.catalog
 
 import com.fishit.player.infra.logging.UnifiedLog
+import com.fishit.player.infra.transport.xtream.XtreamHttpHeaders
 import com.fishit.player.pipeline.xtream.mapper.XtreamCatalogMapper
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -65,7 +66,7 @@ constructor(
             var episodeCount = 0
             var liveCount = 0
 
-            val headers = config.imageAuthHeaders
+            val headers = XtreamHttpHeaders.withDefaults(config.imageAuthHeaders)
 
             // Phase 1: VOD
             if (config.includeVod && currentCoroutineContext().isActive) {

--- a/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/mapper/XtreamImageRefExtensions.kt
+++ b/pipeline/xtream/src/main/java/com/fishit/player/pipeline/xtream/mapper/XtreamImageRefExtensions.kt
@@ -1,6 +1,7 @@
 package com.fishit.player.pipeline.xtream.mapper
 
 import com.fishit.player.core.model.ImageRef
+import com.fishit.player.infra.transport.xtream.XtreamHttpHeaders
 import com.fishit.player.pipeline.xtream.model.XtreamChannel
 import com.fishit.player.pipeline.xtream.model.XtreamEpisode
 import com.fishit.player.pipeline.xtream.model.XtreamSeriesItem
@@ -37,7 +38,7 @@ fun XtreamVodItem.toPosterImageRef(authHeaders: Map<String, String> = emptyMap()
     val url = streamIcon?.takeIf { it.isNotBlank() && it.isValidImageUrl() } ?: return null
     return ImageRef.Http(
             url = url,
-            headers = authHeaders,
+            headers = XtreamHttpHeaders.withDefaults(authHeaders),
             preferredWidth = 300, // Poster width hint
             preferredHeight = 450, // Poster height hint (2:3 aspect)
     )
@@ -57,7 +58,7 @@ fun XtreamSeriesItem.toPosterImageRef(authHeaders: Map<String, String> = emptyMa
     val url = cover?.takeIf { it.isNotBlank() && it.isValidImageUrl() } ?: return null
     return ImageRef.Http(
             url = url,
-            headers = authHeaders,
+            headers = XtreamHttpHeaders.withDefaults(authHeaders),
             preferredWidth = 300,
             preferredHeight = 450,
     )
@@ -77,7 +78,7 @@ fun XtreamEpisode.toThumbnailImageRef(authHeaders: Map<String, String> = emptyMa
     val url = thumbnail?.takeIf { it.isNotBlank() && it.isValidImageUrl() } ?: return null
     return ImageRef.Http(
             url = url,
-            headers = authHeaders,
+            headers = XtreamHttpHeaders.withDefaults(authHeaders),
             preferredWidth = 320, // Thumbnail width hint
             preferredHeight = 180, // Thumbnail height hint (16:9 aspect)
     )
@@ -97,7 +98,7 @@ fun XtreamChannel.toLogoImageRef(authHeaders: Map<String, String> = emptyMap()):
     val url = streamIcon?.takeIf { it.isNotBlank() && it.isValidImageUrl() } ?: return null
     return ImageRef.Http(
             url = url,
-            headers = authHeaders,
+            headers = XtreamHttpHeaders.withDefaults(authHeaders),
             preferredWidth = 120, // Logo width hint
             preferredHeight = 120, // Logo height hint (square)
     )

--- a/playback/xtream/src/main/java/com/fishit/player/playback/xtream/XtreamPlaybackSourceFactoryImpl.kt
+++ b/playback/xtream/src/main/java/com/fishit/player/playback/xtream/XtreamPlaybackSourceFactoryImpl.kt
@@ -4,6 +4,7 @@ import com.fishit.player.core.playermodel.PlaybackContext
 import com.fishit.player.core.playermodel.SourceType
 import com.fishit.player.infra.logging.UnifiedLog
 import com.fishit.player.infra.transport.xtream.XtreamApiClient
+import com.fishit.player.infra.transport.xtream.XtreamHttpHeaders
 import com.fishit.player.playback.domain.DataSourceType
 import com.fishit.player.playback.domain.PlaybackSource
 import com.fishit.player.playback.domain.PlaybackSourceException
@@ -90,7 +91,7 @@ class XtreamPlaybackSourceFactoryImpl @Inject constructor(
                 return PlaybackSource(
                     uri = existingUri,
                     mimeType = determineMimeType(context),
-                    headers = buildHeaders(),
+                    headers = buildHeaders(context),
                     dataSourceType = DataSourceType.DEFAULT
                 )
             } else {
@@ -124,7 +125,7 @@ class XtreamPlaybackSourceFactoryImpl @Inject constructor(
         return PlaybackSource(
             uri = streamUrl,
             mimeType = determineMimeType(context, contentType),
-            headers = buildHeaders(),
+            headers = buildHeaders(context),
             dataSourceType = DataSourceType.DEFAULT
         )
     }
@@ -296,9 +297,9 @@ class XtreamPlaybackSourceFactoryImpl @Inject constructor(
     /**
      * Build HTTP headers for authenticated streams.
      */
-    private fun buildHeaders(): Map<String, String> {
-        return mapOf(
-            "User-Agent" to "FishIT-Player/2.0"
+    private fun buildHeaders(context: PlaybackContext): Map<String, String> =
+        XtreamHttpHeaders.withDefaults(
+            headers = context.headers,
+            referer = xtreamApiClient.capabilities?.baseUrl,
         )
-    }
 }


### PR DESCRIPTION
## Summary
- add a shared XtreamHttpHeaders helper that supplies legacy-compatible defaults
- inject the legacy User-Agent into Xtream transport calls and reuse defaults for playback header construction
- apply the same defaults to Xtream image references when no custom headers are provided so Coil requests stay authenticated

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a5ea97cc83229bdd3a2fadc7dd31)