### PR TITLE
Remove pipeline CLI from frozen manifest guardrail

### DIFF
--- a/docs/v2/FROZEN_MODULE_MANIFEST.md
+++ b/docs/v2/FROZEN_MODULE_MANIFEST.md
@@ -216,17 +216,6 @@ Rules:
 
 ---
 
-## Tools (Owner: Tools)
-### `:tools:pipeline-cli` — **Owner: Tools**
-- **Path:** `tools/pipeline-cli/`
-- **Purpose:** Headless CLI for pipeline/transport testing
-- **Must be headless:** NO Compose plugins, NO AndroidX UI/Compose dependencies, NO Hilt/DI
-- **Allowed deps:** `core:*`, `pipeline:*`, `infra:transport-*`, `infra:logging`, Kotlin stdlib, CLI frameworks (Clikt)
-- **Rule:** This module must remain headless (no UI, no DI) to prevent becoming a backdoor for improper wiring
-- **Note:** Uses Android library plugin due to Android dependencies, but NO Android-specific APIs allowed
-
----
-
 # One-Time Stub PR Scope (Fixed)
 The ONLY modules allowed to be created as new directories during the stub PR:
 1) `infra/imaging`
@@ -248,7 +237,8 @@ CI MUST fail when:
 - `app-v2` depends on `infra:transport-*` or `pipeline:*` via Gradle deps
 - `player:ui` uses `@EntryPoint` or `EntryPointAccessors`
 - `playback:domain` gains any Compose dependencies
-- `:tools:pipeline-cli` declares Compose plugins or AndroidX UI/Compose dependencies (must remain headless)
+
+> Note: `:tools:pipeline-cli` remains outside the frozen manifest and CI guardrails; keep it headless and excluded from module-freeze tracking.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove the tools:pipeline-cli section from the frozen module manifest and note its exclusion from module-freeze tracking
- update the frozen manifest guardrail script to ignore the CLI module and drop the headless-compliance checks

## Testing
- scripts/ci/check-frozen-manifest.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a60148c883228f273fb295386b40)