### PR TITLE
Improve Xtream onboarding parsing and transport reliability

### DIFF
--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -58,4 +58,7 @@ dependencies {
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:2.0.21")
 }

--- a/feature/onboarding/src/test/java/com/fishit/player/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/java/com/fishit/player/feature/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,55 @@
+package com.fishit.player.feature.onboarding
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class OnboardingViewModelTest {
+    @Test
+    fun `parseXtreamUrl handles get php url`() {
+        val url =
+            "http://konigtv.com:8080/get.php?username=Christoph10&password=JQ2rKsQ744&type=m3u_plus&output=ts"
+
+        val credentials = OnboardingViewModel.parseXtreamUrl(url)
+
+        assertNotNull(credentials)
+        assertEquals("konigtv.com", credentials.host)
+        assertEquals(8080, credentials.port)
+        assertEquals("Christoph10", credentials.username)
+        assertEquals(false, credentials.useHttps)
+    }
+
+    @Test
+    fun `parseXtreamUrl handles player api url`() {
+        val url = "http://example.com/player_api.php?username=user&password=pass"
+
+        val credentials = OnboardingViewModel.parseXtreamUrl(url)
+
+        assertNotNull(credentials)
+        assertEquals("example.com", credentials.host)
+        assertEquals(80, credentials.port)
+        assertEquals("user", credentials.username)
+        assertEquals("pass", credentials.password)
+    }
+
+    @Test
+    fun `parseXtreamUrl decodes encoded credentials`() {
+        val url = "http://example.com:8000/get.php?username=User%2BName&password=pa%24%24word"
+
+        val credentials = OnboardingViewModel.parseXtreamUrl(url)
+
+        assertNotNull(credentials)
+        assertEquals("User+Name", credentials.username)
+        assertEquals("pa$$word", credentials.password)
+    }
+
+    @Test
+    fun `parseXtreamUrl returns null for missing credentials`() {
+        val url = "http://example.com/get.php?username=onlyuser"
+
+        val credentials = OnboardingViewModel.parseXtreamUrl(url)
+
+        assertNull(credentials)
+    }
+}

--- a/infra/data-xtream/build.gradle.kts
+++ b/infra/data-xtream/build.gradle.kts
@@ -48,4 +48,5 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test:2.0.21")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("app.cash.turbine:turbine:1.0.0")
 }

--- a/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/XtreamAuthRepositoryAdapter.kt
+++ b/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/XtreamAuthRepositoryAdapter.kt
@@ -17,9 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Named
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -123,26 +121,27 @@ class XtreamAuthRepositoryAdapter @Inject constructor(
      */
     private fun observeTransportStates() {
         transportStateJob?.cancel()
-        transportStateJob = combine(
-            apiClient.connectionState,
-            apiClient.authState,
-        ) { connection, auth ->
-            connection to auth
-        }
-            .onEach { (connection, auth) ->
-                val domainConnection = connection.toDomainConnectionState()
-                if (_connectionState.value != domainConnection) {
-                    UnifiedLog.d(TAG) { "connectionState -> $connection | domain=$domainConnection" }
-                    _connectionState.value = domainConnection
-                }
-
-                val domainAuth = auth.toDomainAuthState()
-                if (_authState.value != domainAuth) {
-                    UnifiedLog.d(TAG) { "authState -> $auth | domain=$domainAuth" }
-                    _authState.value = domainAuth
+        transportStateJob = appScope.launch {
+            launch {
+                apiClient.connectionState.collect { connection ->
+                    val domainConnection = connection.toDomainConnectionState()
+                    if (_connectionState.value != domainConnection) {
+                        UnifiedLog.d(TAG) { "connectionState -> $connection | domain=$domainConnection" }
+                        _connectionState.value = domainConnection
+                    }
                 }
             }
-            .launchIn(appScope)
+
+            launch {
+                apiClient.authState.collect { auth ->
+                    val domainAuth = auth.toDomainAuthState()
+                    if (_authState.value != domainAuth) {
+                        UnifiedLog.d(TAG) { "authState -> $auth | domain=$domainAuth" }
+                        _authState.value = domainAuth
+                    }
+                }
+            }
+        }
     }
 
     // =========================================================================
@@ -186,6 +185,8 @@ class XtreamAuthRepositoryAdapter @Inject constructor(
         is XtreamError.ParseError -> "Parse error: $message"
         is XtreamError.Unsupported -> "Unsupported action: $action"
         is XtreamError.RateLimited -> "Rate limited"
+        is XtreamError.UnexpectedHtml -> message
+        is XtreamError.CdnBlocked -> "Blocked: $message"
         is XtreamError.Unknown -> message
     }
 

--- a/infra/data-xtream/src/test/java/com/fishit/player/infra/data/xtream/XtreamAuthRepositoryAdapterTest.kt
+++ b/infra/data-xtream/src/test/java/com/fishit/player/infra/data/xtream/XtreamAuthRepositoryAdapterTest.kt
@@ -1,0 +1,162 @@
+package com.fishit.player.infra.data.xtream
+
+import app.cash.turbine.test
+import com.fishit.player.feature.onboarding.domain.XtreamAuthState as DomainAuthState
+import com.fishit.player.feature.onboarding.domain.XtreamConfig as DomainConfig
+import com.fishit.player.feature.onboarding.domain.XtreamConnectionState as DomainConnectionState
+import com.fishit.player.infra.transport.xtream.XtreamApiClient
+import com.fishit.player.infra.transport.xtream.XtreamApiConfig
+import com.fishit.player.infra.transport.xtream.XtreamAuthState
+import com.fishit.player.infra.transport.xtream.XtreamCapabilities
+import com.fishit.player.infra.transport.xtream.XtreamCategory
+import com.fishit.player.infra.transport.xtream.XtreamConnectionState
+import com.fishit.player.infra.transport.xtream.XtreamCredentialsStore
+import com.fishit.player.infra.transport.xtream.XtreamStoredConfig
+import com.fishit.player.infra.transport.xtream.XtreamLiveStream
+import com.fishit.player.infra.transport.xtream.XtreamSeriesStream
+import com.fishit.player.infra.transport.xtream.XtreamServerInfo
+import com.fishit.player.infra.transport.xtream.XtreamUserInfo
+import com.fishit.player.infra.transport.xtream.XtreamVodInfo
+import com.fishit.player.infra.transport.xtream.XtreamVodStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class XtreamAuthRepositoryAdapterTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val appScope = CoroutineScope(dispatcher)
+
+    @Test
+    fun `observeTransportStates forwards state changes`() = runTest(dispatcher) {
+        val apiClient = FakeXtreamApiClient()
+        val credentialsStore = InMemoryXtreamCredentialsStore()
+        val adapter = XtreamAuthRepositoryAdapter(apiClient, credentialsStore, appScope)
+
+        val config = DomainConfig(
+            scheme = "http",
+            host = "example.com",
+            port = 8080,
+            username = "user",
+            password = "pass",
+        )
+
+        adapter.connectionState.test {
+            assertTrue(awaitItem() is DomainConnectionState.Disconnected)
+            val initializeResult = adapter.initialize(config)
+            assertTrue(initializeResult.isSuccess)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DomainConnectionState.Connecting)
+
+            apiClient.connectionState.value = XtreamConnectionState.Connected("http://example.com:8080", 12)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DomainConnectionState.Connected)
+            cancelAndConsumeRemainingEvents()
+        }
+
+        adapter.authState.test {
+            assertTrue(awaitItem() is DomainAuthState.Idle)
+            apiClient.authState.value = XtreamAuthState.Pending
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DomainAuthState.Idle)
+
+            val userInfo =
+                XtreamUserInfo(
+                    username = "user",
+                    status = XtreamUserInfo.UserStatus.ACTIVE,
+                    expDateEpoch = 1_700_000_000,
+                    maxConnections = 1,
+                    activeConnections = 0,
+                    isTrial = false,
+                    allowedFormats = emptyList(),
+                    createdAt = null,
+                    message = null,
+                )
+            apiClient.authState.value = XtreamAuthState.Authenticated(userInfo)
+            advanceUntilIdle()
+            assertTrue(awaitItem() is DomainAuthState.Authenticated)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    private class FakeXtreamApiClient : XtreamApiClient {
+        override val authState = MutableStateFlow<XtreamAuthState>(XtreamAuthState.Unknown)
+        override val connectionState = MutableStateFlow<XtreamConnectionState>(XtreamConnectionState.Disconnected)
+        override var capabilities: XtreamCapabilities? = null
+            private set
+
+        override suspend fun initialize(
+            config: XtreamApiConfig,
+            forceDiscovery: Boolean,
+        ): Result<XtreamCapabilities> {
+            connectionState.value = XtreamConnectionState.Connecting
+            val resolvedCaps =
+                XtreamCapabilities(
+                    cacheKey = "${config.scheme}://${config.host}:${config.port ?: 80}|${config.username}",
+                    baseUrl = "${config.scheme}://${config.host}:${config.port ?: 80}",
+                    username = config.username,
+                )
+            capabilities = resolvedCaps
+            return Result.success(resolvedCaps)
+        }
+
+        override suspend fun ping(): Boolean = true
+
+        override fun close() {
+            connectionState.value = XtreamConnectionState.Disconnected
+        }
+
+        override suspend fun getServerInfo(): Result<XtreamServerInfo> = Result.failure(UnsupportedOperationException())
+
+        override suspend fun getUserInfo(): Result<XtreamUserInfo> = Result.failure(UnsupportedOperationException())
+
+        override suspend fun getLiveCategories(): List<XtreamCategory> = emptyList()
+
+        override suspend fun getVodCategories(): List<XtreamCategory> = emptyList()
+
+        override suspend fun getSeriesCategories(): List<XtreamCategory> = emptyList()
+
+        override suspend fun getLiveStreams(
+            categoryId: String?,
+            limit: Int,
+            offset: Int,
+        ): List<XtreamLiveStream> = emptyList()
+
+        override suspend fun getVodStreams(
+            categoryId: String?,
+            limit: Int,
+            offset: Int,
+        ): List<XtreamVodStream> = emptyList()
+
+        override suspend fun getSeries(
+            categoryId: String?,
+            limit: Int,
+            offset: Int,
+        ): List<XtreamSeriesStream> = emptyList()
+
+        override suspend fun getVodInfo(vodId: Int): XtreamVodInfo? = null
+
+        override suspend fun getSeriesInfo(seriesId: Int): Map<String, List<XtreamSeriesStream>> = emptyMap()
+
+        override suspend fun rawApiCall(action: String, params: Map<String, String>): String? = null
+    }
+
+    private class InMemoryXtreamCredentialsStore : XtreamCredentialsStore {
+        var stored: XtreamStoredConfig? = null
+
+        override suspend fun read(): XtreamStoredConfig? = stored
+
+        override suspend fun write(config: XtreamStoredConfig) {
+            stored = config
+        }
+
+        override suspend fun clear() {
+            stored = null
+        }
+    }
+}

--- a/infra/transport-xtream/XTREAM_FIX_REPORT.md
+++ b/infra/transport-xtream/XTREAM_FIX_REPORT.md
@@ -1,0 +1,31 @@
+# Xtream Fix Report
+
+## What was broken
+- Onboarding rejected valid Xtream URLs and ignored percent-encoded credentials.
+- Xtream transport silently accepted HTML/challenge pages and HTTP errors, leading to empty lists instead of explicit failures.
+- Auth/connection state propagation from transport to onboarding domain only reflected snapshots, making UI updates unreliable.
+- Debug traffic inspection for Xtream HTTP calls was missing.
+
+## What changed
+- Updated `OnboardingViewModel.parseXtreamUrl` to URL-decode credentials and added unit coverage for common URL shapes (get.php, player_api.php, encoded values).
+- Added script-parity initialization in `DefaultXtreamApiClient` (preflight player_api, then get_server_info with fallback) and hardened `fetchRaw` to detect HTML/challenge responses, preserving the provided scheme/port.
+- Introduced explicit Xtream errors for HTML challenges and surfaced HTTP failures instead of returning empty data.
+- Switched `XtreamAuthRepositoryAdapter` to continuously collect transport auth/connection flows; added Turbine test for Pending→Authenticated propagation.
+- Wired Chucker (debug-only) into the Xtream OkHttp client with username/password query redaction.
+
+## How to verify locally
+1. **Unit tests**
+   - Run onboarding and Xtream data tests: `./gradlew :feature:onboarding:testDebugUnitTest :infra:data-xtream:testDebugUnitTest`
+2. **Manual onboarding parsing**
+   - Enter `http://konigtv.com:8080/get.php?username=Christoph10&password=JQ2rKsQ744&type=m3u_plus&output=ts` and confirm logs show `host=konigtv.com, port=8080, useHttps=false`.
+3. **Transport requests**
+   - Initialize Xtream with real credentials; observe logs for:
+     - `runScriptParityAuthCheck` preflight URL
+     - `getServerInfo` request and response byte size
+     - Errors for any HTML/challenge pages instead of empty results
+4. **State flow observation**
+   - While requests run, ensure onboarding logs show connection/auth transitions (Pending → Connected/Authenticated or error).
+5. **Chucker (debug build)**
+   - Launch a debug build and open Chucker; confirm player_api/panel_api calls appear with `username`/`password` query params redacted.
+
+Expected log tags: `OnboardingViewModel`, `XtreamAuthRepoAdapter`, `XtreamApiClient`.

--- a/infra/transport-xtream/build.gradle.kts
+++ b/infra/transport-xtream/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
     // Networking
     api("com.squareup.okhttp3:okhttp:5.0.0-alpha.14")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    debugImplementation("com.github.chuckerteam.chucker:library:4.0.0")
+    releaseImplementation("com.github.chuckerteam.chucker:library-no-op:4.0.0")
 
     // Security for credential storage
     implementation("androidx.security:security-crypto:1.1.0-alpha06")

--- a/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/XtreamApiClient.kt
+++ b/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/XtreamApiClient.kt
@@ -433,6 +433,18 @@ sealed interface XtreamError {
         val retryAfterMs: Long?,
     ) : XtreamError
 
+    /** HTML or challenge page instead of expected JSON payload */
+    data class UnexpectedHtml(
+        val message: String,
+        val statusCode: Int? = null,
+    ) : XtreamError
+
+    /** CDN or WAF challenge blocking the request (e.g., Cloudflare) */
+    data class CdnBlocked(
+        val statusCode: Int?,
+        val message: String,
+    ) : XtreamError
+
     /** Unknown error */
     data class Unknown(
         val message: String,

--- a/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/di/XtreamTransportModule.kt
+++ b/infra/transport-xtream/src/main/java/com/fishit/player/infra/transport/xtream/di/XtreamTransportModule.kt
@@ -1,11 +1,15 @@
 package com.fishit.player.infra.transport.xtream.di
 
+import android.content.Context
+import com.chuckerteam.chucker.api.ChuckerInterceptor
+import com.fishit.player.infra.transport.xtream.BuildConfig
 import com.fishit.player.infra.transport.xtream.DefaultXtreamApiClient
 import com.fishit.player.infra.transport.xtream.EncryptedXtreamCredentialsStore
 import com.fishit.player.infra.transport.xtream.XtreamApiClient
 import com.fishit.player.infra.transport.xtream.XtreamCredentialsStore
 import com.fishit.player.infra.transport.xtream.XtreamDiscovery
 import com.fishit.player.infra.transport.xtream.XtreamHttpHeaders
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -26,7 +30,9 @@ import javax.inject.Singleton
 object XtreamTransportModule {
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient =
+    fun provideOkHttpClient(
+        @ApplicationContext context: Context,
+    ): OkHttpClient =
         OkHttpClient
             .Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
@@ -43,6 +49,17 @@ object XtreamTransportModule {
                 }
 
                 chain.proceed(builder.build())
+            }
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addInterceptor(
+                        ChuckerInterceptor
+                            .Builder(context)
+                            .redactQueryParameter("password")
+                            .redactQueryParameter("username")
+                            .build(),
+                    )
+                }
             }
             .build()
 


### PR DESCRIPTION
## Summary
- decode Xtream onboarding URLs, handle percent-encoded credentials, and cover common inputs with unit tests
- add script-parity auth checks, HTML/challenge detection, and debug-only Chucker interception to the Xtream transport client
- stream Xtream auth/connection state changes continuously, add flow tests, and document the fixes in XTREAM_FIX_REPORT

## Testing
- :feature/onboarding:testDebugUnitTest *(fails: Android SDK location is not configured in this environment)*
- :infra:data-xtream:testDebugUnitTest *(fails: Android SDK location is not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470a8ec3bc832280fb8c1d8e9b05a2)