### PR TITLE
Use RawMediaMetadata ImageRef fields for Xtream library items

### DIFF
--- a/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/LibraryContentRepositoryAdapter.kt
+++ b/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/LibraryContentRepositoryAdapter.kt
@@ -1,6 +1,5 @@
 package com.fishit.player.infra.data.xtream
 
-import com.fishit.player.core.model.ImageRef
 import com.fishit.player.core.model.RawMediaMetadata
 import com.fishit.player.feature.library.domain.LibraryCategory
 import com.fishit.player.feature.library.domain.LibraryContentRepository
@@ -108,13 +107,13 @@ class LibraryContentRepositoryAdapter @Inject constructor(
     private fun RawMediaMetadata.toLibraryMediaItem(): LibraryMediaItem {
         return LibraryMediaItem(
             id = sourceId,
-            title = title,
-            poster = posterUrl?.let { ImageRef(it) },
-            backdrop = backdropUrl?.let { ImageRef(it) },
+            title = originalTitle,
+            poster = poster ?: thumbnail,
+            backdrop = backdrop,
             mediaType = mediaType,
             sourceType = sourceType,
             year = year,
-            rating = rating,
+            rating = rating?.toFloat(),
             categoryId = extras["categoryId"],
             categoryName = extras["categoryName"],
             genres = extras["genres"]?.split(",")?.map { it.trim() } ?: emptyList(),


### PR DESCRIPTION
### Motivation
- Align Xtream data-layer mapping with the imaging contract by using `RawMediaMetadata` image fields instead of constructing `ImageRef` from raw URLs. 
- Ensure the library UI consumes canonical `ImageRef` instances produced by pipelines/normalizer and avoid creating new `ImageRef` objects in the data layer. 
- Use the pipeline-provided `originalTitle` (source-provided, unnormalized) for display to preserve source fidelity until normalizer runs. 
- Prevent precision loss by converting the source `rating: Double?` into the feature-level `rating: Float?` consistently.

### Description
- Updated `infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/LibraryContentRepositoryAdapter.kt` to map `title = originalTitle` and to use `poster = poster ?: thumbnail` and `backdrop = backdrop` (both `ImageRef?`) from `RawMediaMetadata` instead of constructing `ImageRef` from URLs. 
- Removed explicit `ImageRef(...)` construction and the now-unused `ImageRef` import so the adapter re-uses pipeline/normalizer `ImageRef` instances or `ImageRef.fromString(...)` when needed elsewhere. 
- Converted `rating` from `Double?` to `Float?` at the mapping site using `rating?.toFloat()` to match `LibraryMediaItem.rating` type. 
- Change is localized to the adapter mapping function `RawMediaMetadata.toLibraryMediaItem()` and does not introduce new dependencies or cross-layer imports.

### Testing
- Ran pipeline architecture audit grep checks (`grep -rn "import.*data\.obx\|import.*ObxTelegram\|import.*ObxXtream" pipeline/` and related `grep` commands) and observed no new pipeline/data layer import violations; one existing import in `infra/data-telegram` references a feature domain model and was left unchanged. 
- No unit tests or Gradle builds were executed for this change. 
- Static/formatting checks were not modified as part of this patch. 
- Manual review confirmed the mapping now re-uses `ImageRef` instances from `RawMediaMetadata` and converts rating safely with `rating?.toFloat()`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be66d652c832289be392d6027b135)