### PR TITLE
Map LiveChannel from RawMediaMetadata: use originalTitle, ImageRef poster/thumbnail, and sourceType

### DIFF
--- a/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/LiveContentRepositoryAdapter.kt
+++ b/infra/data-xtream/src/main/java/com/fishit/player/infra/data/xtream/LiveContentRepositoryAdapter.kt
@@ -1,8 +1,6 @@
 package com.fishit.player.infra.data.xtream
 
-import com.fishit.player.core.model.ImageRef
 import com.fishit.player.core.model.RawMediaMetadata
-import com.fishit.player.core.model.SourceType
 import com.fishit.player.feature.live.domain.LiveCategory
 import com.fishit.player.feature.live.domain.LiveChannel
 import com.fishit.player.feature.live.domain.LiveContentRepository
@@ -129,16 +127,16 @@ class LiveContentRepositoryAdapter @Inject constructor(
     private fun RawMediaMetadata.toLiveChannel(): LiveChannel {
         return LiveChannel(
             id = sourceId,
-            name = title,
+            name = originalTitle,
             channelNumber = extras["channelNumber"]?.toIntOrNull(),
-            logo = posterUrl?.let { ImageRef.Remote(it) },
+            logo = poster ?: thumbnail,
             categoryId = extras["categoryId"],
             categoryName = extras["categoryName"],
             currentProgram = extras["currentProgram"],
             currentProgramDescription = extras["currentProgramDescription"],
             programStart = extras["programStart"]?.toLongOrNull(),
             programEnd = extras["programEnd"]?.toLongOrNull(),
-            sourceType = SourceType.XTREAM,
+            sourceType = sourceType,
             isFavorite = favoriteIds.contains(sourceId),
             lastWatched = if (recentChannelIds.contains(sourceId)) {
                 System.currentTimeMillis()


### PR DESCRIPTION
### Motivation
- Align live channel mapping with the v2 `RawMediaMetadata` imaging and naming contract to keep pipelines → data boundaries clean.
- Ensure the data layer does not synthesize image URLs or hard-code a single `SourceType`, allowing multiple sources in future.
- Use pipeline-provided `ImageRef` fields as the single source of truth for logos and thumbnails.
- Improve UI robustness by falling back to `thumbnail` when `poster` is not available.

### Description
- In `LiveContentRepositoryAdapter` replace `title` with `RawMediaMetadata.originalTitle` for the channel `name`.
- Use `poster ?: thumbnail` (both `ImageRef?`) as the channel `logo` instead of creating `ImageRef.Remote` from a URL.
- Use the `RawMediaMetadata.sourceType` value for `LiveChannel.sourceType` instead of the hard-coded `SourceType.XTREAM`.
- Removed now-unused imports and kept the mapping purely sourced from `RawMediaMetadata` fields.

### Testing
- Ran the pipeline boundary audit command `grep -rn "import.*data\.obx\|import.*ObxTelegram\|import.*ObxXtream" pipeline/` with no matches indicating no forbidden pipeline imports were introduced.
- Ran the data-layer DTO import check `grep -rn "import.*TelegramMediaItem\|import.*XtreamVodItem\|import.*XtreamSeriesItem\|import.*XtreamChannel" infra/data-*/` which reported a pre-existing unrelated import in `infra/data-telegram` but nothing introduced by this change.
- Checked playback imports for forbidden pipeline DTOs with `grep` and found no matches related to this change.
- No compilation or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be875f9888322aa3ad067a6e173d9)